### PR TITLE
Feature functional tests (#62)

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -14,205 +14,213 @@ START_TIME=$SECONDS
 IS_ERROR=false
 AMOUNT_ERRORS=0
 
-# Meta commands
-printf "\033[4mTest display of help (h)\033[0m\n"
-bats ./test/functional/help.bats.sh
-if [ $? -ne 0 ]; then
+if [ "$1" != "" ]; then
+  bats ./test/functional/"$1".bats.sh
+  if [ $? -ne 0 ]; then
   IS_ERROR=true
   ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  fi
+else
+  # Meta commands
+  printf "\033[4mTest display of help (h)\033[0m\n"
+  bats ./test/functional/help.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest display of version number (v)\033[0m\n"
-bats ./test/functional/version.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest display of version number (v)\033[0m\n"
+  bats ./test/functional/version.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-# List DOCX contents:
-printf "\n\033[4mTest listing files in DOCX (ls)\033[0m\n"
-bats ./test/functional/ls.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  # List DOCX contents:
+  printf "\n\033[4mTest listing files in DOCX (ls)\033[0m\n"
+  bats ./test/functional/ls.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest listing files in DOCX as JSON (lsj)\033[0m\n"
-bats ./test/functional/lsj.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest listing files in DOCX as JSON (lsj)\033[0m\n"
+  bats ./test/functional/lsj.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest listing fields in DOCX (lsd)\033[0m\n"
-bats ./test/functional/lsd.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest listing fields in DOCX (lsd)\033[0m\n"
+  bats ./test/functional/lsd.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest listing fields in DOCX as JSON (lsdj)\033[0m\n"
-bats ./test/functional/lsdj.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest listing fields in DOCX as JSON (lsdj)\033[0m\n"
+  bats ./test/functional/lsdj.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest listing referenced fonts in DOCX (lsf)\033[0m\n"
-bats ./test/functional/lsf.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest listing referenced fonts in DOCX (lsf)\033[0m\n"
+  bats ./test/functional/lsf.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest listing referenced fonts in DOCX as JSON (lsfj)\033[0m\n"
-bats ./test/functional/lsfj.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest listing referenced fonts in DOCX as JSON (lsfj)\033[0m\n"
+  bats ./test/functional/lsfj.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest listing images in DOCX (lsi)\033[0m\n"
-bats ./test/functional/lsi.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest listing images in DOCX (lsi)\033[0m\n"
+  bats ./test/functional/lsi.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest listing images in DOCX as JSON (lsij)\033[0m\n"
-bats ./test/functional/lsij.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest listing images in DOCX as JSON (lsij)\033[0m\n"
+  bats ./test/functional/lsij.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest listing files containing given string (lsl)\033[0m\n"
-bats ./test/functional/lsl.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest listing files containing given string (lsl)\033[0m\n"
+  bats ./test/functional/lsl.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest listing files containing given string as JSON (lslj)\033[0m\n"
-bats ./test/functional/lslj.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest listing files containing given string as JSON (lslj)\033[0m\n"
+  bats ./test/functional/lslj.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest listing metadata in DOCX (lsm)\033[0m\n"
-bats ./test/functional/lsm.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest listing metadata in DOCX (lsm)\033[0m\n"
+  bats ./test/functional/lsm.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest listing metadata in DOCX as JSON (lsmj)\033[0m\n"
-bats ./test/functional/lsmj.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest listing metadata in DOCX as JSON (lsmj)\033[0m\n"
+  bats ./test/functional/lsmj.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-# Convert and compare DOCX:
-printf "\n\033[4mTest output XML document\033[0m\n"
-bats ./test/functional/cat.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  # Convert and compare DOCX:
+  printf "\n\033[4mTest output XML document\033[0m\n"
+  bats ./test/functional/cat.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest output DOCX document as plaintext (txt)\033[0m\n"
-bats ./test/functional/txt.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest output DOCX document as plaintext (txt)\033[0m\n"
+  bats ./test/functional/txt.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest side-by-side comparison from two DOCX archives (diff)\033[0m\n"
-bats ./test/functional/diff.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest side-by-side comparison from two DOCX archives (diff)\033[0m\n"
+  bats ./test/functional/diff.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-# Manipulate DOCX:
-printf "\n\033[4mTest replacing text with dummy text in DOCX (lorem)\033[0m\n"
-bats ./test/functional/lorem.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  # Manipulate DOCX:
+  printf "\n\033[4mTest replacing text with dummy text in DOCX (lorem)\033[0m\n"
+  bats ./test/functional/lorem.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest replacing image in DOCX (rpi)\033[0m\n"
-bats ./test/functional/rpi.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest replacing image in DOCX (rpi)\033[0m\n"
+  bats ./test/functional/rpi.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest replacing text in DOCX (rpt)\033[0m\n"
-bats ./test/functional/rpt.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest replacing text in DOCX (rpt)\033[0m\n"
+  bats ./test/functional/rpt.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest modifying or setting metadata in DOCX (mm)\033[0m\n"
-bats ./test/functional/mm.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest modifying or setting metadata in DOCX (mm)\033[0m\n"
+  bats ./test/functional/mm.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest removing DOCX contens between given strings (rmt)\033[0m\n"
-bats ./test/functional/rmt.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest removing DOCX contens between given strings (rmt)\033[0m\n"
+  bats ./test/functional/rmt.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest setting field value in DOCX (sfv)\033[0m\n"
-bats ./test/functional/sfv.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest setting field value in DOCX (sfv)\033[0m\n"
+  bats ./test/functional/sfv.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-# Extract and create DOCX:
-printf "\n\033[4mTest unziping files from DOCX (uz)\033[0m\n"
-bats ./test/functional/uz.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  # Extract and create DOCX:
+  printf "\n\033[4mTest unziping files from DOCX (uz)\033[0m\n"
+  bats ./test/functional/uz.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest unziping files from DOCX and indenting XML files (uzi)\033[0m\n"
-bats ./test/functional/uzi.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest unziping files from DOCX and indenting XML files (uzi)\033[0m\n"
+  bats ./test/functional/uzi.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest unziping only media files from DOCX (uzm)\033[0m\n"
-bats ./test/functional/uzm.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest unziping only media files from DOCX (uzm)\033[0m\n"
+  bats ./test/functional/uzm.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest creating (zp) DOCX from files (zp)\033[0m\n"
-bats ./test/functional/zp.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
-fi
+  printf "\n\033[4mTest creating (zp) DOCX from files (zp)\033[0m\n"
+  bats ./test/functional/zp.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 
-printf "\n\033[4mTest creating DOCX from indented files (zpc)\033[0m\n"
-bats ./test/functional/zpc.bats.sh
-if [ $? -ne 0 ]; then
-  IS_ERROR=true
-  ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  printf "\n\033[4mTest creating DOCX from indented files (zpc)\033[0m\n"
+  bats ./test/functional/zpc.bats.sh
+  if [ $? -ne 0 ]; then
+    IS_ERROR=true
+    ((AMOUNT_ERRORS=AMOUNT_ERRORS+1))
+  fi
 fi
 
 ELAPSED_TIME=$(($SECONDS - $START_TIME))

--- a/test/functional/rpi.bats.sh
+++ b/test/functional/rpi.bats.sh
@@ -8,7 +8,7 @@ load _helper
 docxbox=""$BATS_TEST_DIRNAME"/docxbox"
 path_docx="test/functional/tmp/cp_table_unordered_list_images.docx"
 path_extracted_image="test/functional/tmp/unziped/word/media/image2.jpeg"
-path_jpeg="test/files/images/2100x400.jpeg"
+path_jpeg="test/assets/images/2100x400.jpeg"
 
 
 base_command="docxbox rpi filename.docx"

--- a/test/functional/rpt.bats.sh
+++ b/test/functional/rpt.bats.sh
@@ -100,19 +100,18 @@ appendix_new_docx="the stringToBeReplaced gets replaced and is saved to new file
   "${docxbox}" lsl "${path_docx}" "w:numPr" | grep --count "${display_file}"
 }
 
-# ordered list can not be inserted atm, so no assertions can be made
-#@test "With \"${base_command} ol_as_JSON\" the given string is replaced by a ordered list" {
-#  list="{\"ol\":{\"items\":[\"item-1\",\"item-2\",\"item-3\"]}}"
-#  path_docx="test/functional/tmp/cp_bio_assay.docx"
-#
-#  "${docxbox}" cat "${path_docx}" "${display_file}" | grep --invert-match "<w:numId w:val=\"2\"/>"
-#
-#  run "${docxbox}" rpt "${path_docx}" 5NISINisi ${list}
-#  [ "$status" -eq 0 ]
-#
-#  "${docxbox}" cat "${path_docx}" "${display_file}" | grep --count "<w:numId w:val=\"2\"/>"
-#  "${docxbox}" lsl "${path_docx}" "w:numPr" | grep --count "${display_file}"
-#}
+@test "With \"${base_command} ol_as_JSON\" the given string is replaced by a ordered list" {
+  list="{\"ol\":{\"items\":[\"item-1\",\"item-2\",\"item-3\"]}}"
+  path_docx="test/functional/tmp/cp_bio_assay.docx"
+
+  "${docxbox}" cat "${path_docx}" "${display_file}" | grep --invert-match "<w:numId w:val=\"2\"/>"
+
+  run "${docxbox}" rpt "${path_docx}" 5NISINisi ${list}
+  [ "$status" -eq 0 ]
+
+  "${docxbox}" cat "${path_docx}" "${display_file}" | grep --count "<w:numId w:val=\"2\"/>"
+  "${docxbox}" lsl "${path_docx}" "w:numPr" | grep --count -q "${display_file}"
+}
 
 @test "With \"${base_command} hyperlink_as_JSON\" the given string is replaced by a hyperlink" {
   url="\"url\":\"https://github.com/gyselroth/docxbox\""
@@ -130,7 +129,7 @@ appendix_new_docx="the stringToBeReplaced gets replaced and is saved to new file
 image_replacement="the given string is replaced by an image"
 @test "With \"${base_command} image_as_JSON\" ${image_replacement} using EMU" {
   image="{\"image\":{\"size\":[2438400,1828800]}}"
-  image_path="test/files/images/2100x400.jpeg"
+  image_path="test/assets/images/2100x400.jpeg"
 
   "${docxbox}" cat "${path_docx}" "${display_file}" | grep --invert-match "<w:drawing>"
   "${docxbox}" cat "${path_docx}" "${display_file}" | grep --invert-match "</w:drawing>"
@@ -146,7 +145,7 @@ image_replacement="the given string is replaced by an image"
 
 @test "With \"${base_command} image_as_JSON\" ${image_replacement} using pixels" {
   image="{\"image\":{\"size\":[\"2100px\",\"400px\"]}}"
-  image_path="test/files/images/2100x400.jpeg"
+  image_path="test/assets/images/2100x400.jpeg"
 
   "${docxbox}" cat "${path_docx}" "${display_file}" | grep --invert-match "<w:drawing>"
   "${docxbox}" cat "${path_docx}" "${display_file}" | grep --invert-match "</w:drawing>"
@@ -175,7 +174,8 @@ image_replacement="the given string is replaced by an image"
   run "${docxbox}" rpt "${path_docx}" Officia ${table}
   [ "$status" -eq 0 ]
 
-  grep --count "header_one" "${path_docx}"
+  "${docxbox}" lsl "${path_docx}" "header_one" | grep --count -q "${display_file}"
+  "${docxbox}" cat "${path_docx}" "${display_file}" | grep --count -q "header_one"
 
   "${docxbox}" cat "${path_docx}" "${display_file}" | grep --count "${pattern}"
   "${docxbox}" lsl "${path_docx}" "<w:tbl>" | grep --count "${display_file}"


### PR DESCRIPTION
* implemented new testSuite cat.bats.sh

* implemented new testCase asserting if an error message is displayed when a none-existing image is given

* removed faulty docx files

* added corrected (and valid) docx files

* corrected testSuite after changes in mock-files

* corrected testSuite after changes in mock-files +1

* reverted accidentally committed test.sh

* corrected testSuite after changes in mock-files +1

* corrected testSuite after changes in mock-files +1

* reverted accidentally committed test.sh

* added corrected (and valid) docx files +1

* reverted accidentally committed test.sh

* corrected testSuite after changes in mock-files +1

* corrected testSuite after changes in mock-files +1

* corrected testSuite after changes in mock-files +1

* extended rpt.bats.sh - replace string by headings, ul, ol, hyperlink, image or table

* extended diff.bats.sh - assertion if a side-by-side view is displayed is more strict
extended ls.bats.sh - asserts if a side-by-side view is displayed

* corrected mock-file

* removed faulty docx

* added docx with valid mergefields

* removed faulty docx

* added docx with valid mergefields in header and footer

* corrected testSuite after merge with master-branch

* extended lsd.bats.sh - checks for fields in header and footer

* extended zp.bats.sh
added zpc.bats.sh

* extended rpt.bats.sh - added testCase asserting if text can be replaced by an image as JSON using pixels instead of EMUs

* resolves #59: added error collection

* corrected testSuite after changes in displayed messages
corrected if condition in test.sh

* added new exit code to test.sh depending if an error occurred
added new testCase to rpt.bats.sh - test asserts if table-header-row is contained
corrected txt.bats.sh after changes in displayed messages

* corrected image pathts after changes in file structure

* single testSuites can be called from cli as additional command