### PR TITLE
numbered all test cases (#84)

### DIFF
--- a/test/functional/batch.bats.sh
+++ b/test/functional/batch.bats.sh
@@ -32,7 +32,7 @@ title_one_missing_argument="Case 1: Output of \"docxbox batch \
   check_for_valgrind_error
 }
 
-title_two_missing_arguments="Case 2:Output of \"${BASE_COMMAND} \
+title_two_missing_arguments="Case 2: Output of \"${BASE_COMMAND} \
 {missing argument}\" is an error message"
 @test "${title_two_missing_arguments}" {
   run ${DOCXBOX_BINARY} batch "${PATH_DOCX}"

--- a/test/functional/cat.bats.sh
+++ b/test/functional/cat.bats.sh
@@ -21,7 +21,7 @@ fi
 PATH_DOCX="test/tmp/cp_table_unordered_list_images.docx"
 PATH_XML="word/document.xml"
 
-@test "Output of \"docxbox cat {missing argument}\" is an error message" {
+@test "Case 1: Output of \"docxbox cat {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} cat
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: DOCX filename" = "${lines[0]}" ]
@@ -29,7 +29,7 @@ PATH_XML="word/document.xml"
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox cat filename.docx {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox cat filename.docx {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} cat "${PATH_DOCX}"
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: File to be displayed" = "${lines[0]}" ]
@@ -37,7 +37,7 @@ PATH_XML="word/document.xml"
   check_for_valgrind_error
 }
 
-@test "With \"docxbox cat filename.docx filename.xml\" the XML is displayed" {
+@test "Case 3: With \"docxbox cat filename.docx filename.xml\" the XML is displayed" {
   ${DOCXBOX_BINARY} cat "${PATH_DOCX}" "${PATH_XML}" | grep "^[[:space:]]\{4\}"
 
   check_for_valgrind_error

--- a/test/functional/diff.bats.sh
+++ b/test/functional/diff.bats.sh
@@ -26,7 +26,7 @@ ERR_LOG="test/tmp/err.log"
 BASE_COMMAND="docxbox diff filename.docx"
 ERROR_MESSAGE="is an error message"
 
-@test "Output of \"docxbox diff {missing argument}\" ${ERROR_MESSAGE}" {
+@test "Case 1: Output of \"docxbox diff {missing argument}\" ${ERROR_MESSAGE}" {
   run ${DOCXBOX_BINARY} diff
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: DOCX file to compare with" = "${lines[0]}" ]
@@ -34,7 +34,7 @@ ERROR_MESSAGE="is an error message"
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND} {missing argument}\" ${ERROR_MESSAGE}" {
+@test "Case 2: Output of \"${BASE_COMMAND} {missing argument}\" ${ERROR_MESSAGE}" {
   path_docx="test/tmp/cp_table_unordered_list_images.docx"
   pattern="docxBox Error - Missing argument: DOCX file to compare with"
 
@@ -45,7 +45,7 @@ ERROR_MESSAGE="is an error message"
   check_for_valgrind_error
 }
 
-title="Output of \"${BASE_COMMAND} otherFilename.docx {missing argument}\""
+title="Case 3: Output of \"${BASE_COMMAND} otherFilename.docx {missing argument}\""
 @test "${title} ${ERROR_MESSAGE}" {
   pattern="docxBox Error - Missing argument: File within DOCX archives to be compared"
 
@@ -56,8 +56,8 @@ title="Output of \"${BASE_COMMAND} otherFilename.docx {missing argument}\""
   check_for_valgrind_error
 }
 
-description="side by side view is displayed"
-@test "With \"${BASE_COMMAND} changedFilename.docx\" a ${description}" {
+DESCRIPTION="side by side view is displayed"
+@test "Case 4: With \"${BASE_COMMAND} changedFilename.docx\" a ${DESCRIPTION}" {
   path_changed_docx="test/tmp/cp_table_unordered_list_images_v2.docx"
   
   run ${DOCXBOX_BINARY} lorem "${PATH_DOCX_1}" "${path_changed_docx}"
@@ -70,7 +70,7 @@ description="side by side view is displayed"
   check_for_valgrind_error
 }
 
-@test "With \"${BASE_COMMAND} changedFilename.docx -u\" a unified ${description}" {
+@test "Case 5: With \"${BASE_COMMAND} changedFilename.docx -u\" a unified ${DESCRIPTION}" {
   path_changed_docx="test/tmp/cp_table_unordered_list_images_v2.docx"
 
   run ${DOCXBOX_BINARY} rpt "${PATH_DOCX_1}" Officia Foo "${path_changed_docx}"
@@ -83,7 +83,7 @@ description="side by side view is displayed"
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox diff nonexistent.docx\" is an error message" {
+@test "Case 6: Output of \"docxbox diff nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} diff nonexistent.docx nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -93,7 +93,7 @@ description="side by side view is displayed"
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox diff wrongFileType\" is an error message" {
+@test "Case 7: Output of \"docxbox diff wrongFileType\" is an error message" {
   pattern="docxBox Error - File is no ZIP archive:"
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"

--- a/test/functional/help.bats.sh
+++ b/test/functional/help.bats.sh
@@ -21,44 +21,44 @@ fi
 REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
 
 # Meta commands
-@test "Running w/o any command displays help" {
+@test "Case 1: Running w/o any command displays help" {
   ${DOCXBOX_BINARY} | grep "Usage: docxbox <command> \[args\]"
 
   check_for_valgrind_error
 }
 
-@test "Running w/o any command displays version" {
+@test "Case 2: Running w/o any command displays version" {
   ${DOCXBOX_BINARY} | grep --perl-regexp --only-matching "${REGEX_VERSION_CHECK}"
 
   check_for_valgrind_error
 }
 
-@test "\"docxbox h\" displays help" {
+@test "Case 3: \"docxbox h\" displays help" {
   ${DOCXBOX_BINARY} h | grep "Usage: docxbox <command> \[args\]"
 
   check_for_valgrind_error
 }
 
-@test "\"docxbox h\" displays version" {
+@test "Case 4: \"docxbox h\" displays version" {
   ${DOCXBOX_BINARY} h | grep --perl-regexp --only-matching "${REGEX_VERSION_CHECK}"
 
   check_for_valgrind_error
 }
 
-@test "\"docxbox ?\" displays help" {
+@test "Case 5: \"docxbox ?\" displays help" {
   ${DOCXBOX_BINARY} ? | grep "Usage: docxbox <command> \[args\]"
 
   check_for_valgrind_error
 }
 
-@test "\"docxbox ?\" displays version" {
+@test "Case 6: \"docxbox ?\" displays version" {
   ${DOCXBOX_BINARY} ? | grep --perl-regexp --only-matching "${REGEX_VERSION_CHECK}"
 
   check_for_valgrind_error
 }
 
 # List DOCX contents:
-@test "\"docxbox h ls\" displays help for ls command" {
+@test "Case 7: \"docxbox h ls\" displays help for ls command" {
   run ${DOCXBOX_BINARY} h ls
   [ "$status" -eq 0 ]
   [ "Command: ls - List DOCX contents:" = "${lines[0]}" ]
@@ -66,7 +66,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h lsj\" displays help for lsj command" {
+@test "Case 8: \"docxbox h lsj\" displays help for lsj command" {
   run ${DOCXBOX_BINARY} h lsj
   [ "$status" -eq 0 ]
   [ "Command: ls - List DOCX contents:" = "${lines[0]}" ]
@@ -74,7 +74,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h lsl\" displays help for lsl command" {
+@test "Case 9: \"docxbox h lsl\" displays help for lsl command" {
   pattern="List all files containing search-string or regular expression:"
 
   run ${DOCXBOX_BINARY} h lsl
@@ -84,7 +84,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h lslj\" displays help for lslj command" {
+@test "Case 10: \"docxbox h lslj\" displays help for lslj command" {
   pattern="List all files containing search-string or regular expression:"
 
   run ${DOCXBOX_BINARY} h lslj
@@ -94,7 +94,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h lsf\" displays help for lsf command" {
+@test "Case 11: \"docxbox h lsf\" displays help for lsf command" {
   run ${DOCXBOX_BINARY} h lsf
   [ "$status" -eq 0 ]
   [ "Command: lsf - List fonts referenced in DOCX:" = "${lines[0]}" ]
@@ -102,7 +102,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h lsfj\" displays help for lsfj command" {
+@test "Case 12: \"docxbox h lsfj\" displays help for lsfj command" {
   run ${DOCXBOX_BINARY} h lsfj
   [ "$status" -eq 0 ]
   [ "Command: lsf - List fonts referenced in DOCX:" = "${lines[0]}" ]
@@ -110,7 +110,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h lsd\" displays help for lsd command" {
+@test "Case 13: \"docxbox h lsd\" displays help for lsd command" {
   run ${DOCXBOX_BINARY} h lsd
   [ "$status" -eq 0 ]
   [ "Command: lsd - List fields from DOCX:" = "${lines[0]}" ]
@@ -118,7 +118,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h lsdj\" displays help for lsdj command" {
+@test "Case 14: \"docxbox h lsdj\" displays help for lsdj command" {
   run ${DOCXBOX_BINARY} h lsdj
   [ "$status" -eq 0 ]
   [ "Command: lsd - List fields from DOCX:" = "${lines[0]}" ]
@@ -126,7 +126,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h lsi\" displays help for lsi command" {
+@test "Case 15: \"docxbox h lsi\" displays help for lsi command" {
   run ${DOCXBOX_BINARY} h lsi
   [ "$status" -eq 0 ]
   [ "Command: lsf - List images in DOCX:" = "${lines[0]}" ]
@@ -134,7 +134,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h lsij\" displays help for lsij command" {
+@test "Case 16: \"docxbox h lsij\" displays help for lsij command" {
   run ${DOCXBOX_BINARY} h lsij
   [ "$status" -eq 0 ]
   [ "Command: lsf - List images in DOCX:" = "${lines[0]}" ]
@@ -142,7 +142,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h lsm\" displays help for lsm command" {
+@test "Case 17: \"docxbox h lsm\" displays help for lsm command" {
   run ${DOCXBOX_BINARY} h lsm
   [ "$status" -eq 0 ]
   [ "Command: lsm - List meta data of DOCX:" = "${lines[0]}" ]
@@ -150,7 +150,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h lsmj\" displays help for lsmj command" {
+@test "Case 18: \"docxbox h lsmj\" displays help for lsmj command" {
   run ${DOCXBOX_BINARY} h lsmj
   [ "$status" -eq 0 ]
   [ "Command: lsm - List meta data of DOCX:" = "${lines[0]}" ]
@@ -159,7 +159,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
 }
 
 # Manipulate DOCX document:
-@test "\"docxbox h rpi\" displays help for rpi command" {
+@test "Case 19: \"docxbox h rpi\" displays help for rpi command" {
   run ${DOCXBOX_BINARY} h rpi
   [ "$status" -eq 0 ]
   [ "Command: rpi - Replace image in DOCX document:" = "${lines[0]}" ]
@@ -167,7 +167,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h rpt\" displays help for rpt command" {
+@test "Case 20: \"docxbox h rpt\" displays help for rpt command" {
   run ${DOCXBOX_BINARY} h rpt
   [ "$status" -eq 0 ]
   [ "Command: rpt - Replace text in DOCX document:" = "${lines[0]}" ]
@@ -175,7 +175,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h rmt\" displays help for rmt command" {
+@test "Case 21: \"docxbox h rmt\" displays help for rmt command" {
   pattern="Command: rmt - Remove DOCX content between given strings:"
 
   run ${DOCXBOX_BINARY} h rmt
@@ -185,7 +185,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h mm\" displays help for mm command" {
+@test "Case 22: \"docxbox h mm\" displays help for mm command" {
   run ${DOCXBOX_BINARY} h mm
   [ "$status" -eq 0 ]
   [ "Command: mm - Modify or set meta attribute in DOCX:" = "${lines[0]}" ]
@@ -193,7 +193,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h sfv\" displays help for sfv command" {
+@test "Case 23: \"docxbox h sfv\" displays help for sfv command" {
   run ${DOCXBOX_BINARY} h sfv
   [ "$status" -eq 0 ]
   [ "Command: sfv - Set field value:" = "${lines[0]}" ]
@@ -202,7 +202,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
 }
 
 # Convert DOCX:
-@test "\"docxbox h txt\" displays help for txt command" {
+@test "Case 24: \"docxbox h txt\" displays help for txt command" {
   run ${DOCXBOX_BINARY} h txt
   [ "$status" -eq 0 ]
   [ "Command: txt - Output plaintext from DOCX document:" = "${lines[0]}" ]
@@ -210,7 +210,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h diff\" displays help for diff command" {
+@test "Case 25: \"docxbox h diff\" displays help for diff command" {
   pattern="Command diff - Side-by-side compare file from two DOCX archives:"
 
   run ${DOCXBOX_BINARY} h diff
@@ -221,7 +221,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
 }
 
 # Batch process
-@test "\"docxbox h batch\" displays help for batch command" {
+@test "Case 26: \"docxbox h batch\" displays help for batch command" {
   pattern="Command batch - Process multiple docxBox commands upon given DOCX"
 
   run ${DOCXBOX_BINARY} h batch
@@ -232,7 +232,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
 }
 
 # Extract and create DOCX:
-@test "\"docxbox h uz\" displays help for uz command" {
+@test "Case 27: \"docxbox h uz\" displays help for uz command" {
   run ${DOCXBOX_BINARY} h uz
   [ "$status" -eq 0 ]
   [ "Command: uz - Unzip given DOCX file:" = "${lines[0]}" ]
@@ -240,7 +240,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h uzi\" displays help for uzi command" {
+@test "Case 28: \"docxbox h uzi\" displays help for uzi command" {
   run ${DOCXBOX_BINARY} h uzi
   [ "$status" -eq 0 ]
   [ "Command: uzi - Unzip DOCX and indent XML files:" = "${lines[0]}" ]
@@ -248,7 +248,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h uzm\" displays help for uzm command" {
+@test "Case 29: \"docxbox h uzm\" displays help for uzm command" {
   run ${DOCXBOX_BINARY} h uzm
   [ "$status" -eq 0 ]
   [ "Command: uzm - Unzip only media files DOCX file:" = "${lines[0]}" ]
@@ -256,7 +256,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h zp\" displays help for zp command" {
+@test "Case 30: \"docxbox h zp\" displays help for zp command" {
   run ${DOCXBOX_BINARY} h zp
   [ "$status" -eq 0 ]
   [ "Command: zp - Create (zip) DOCX from files:" = "${lines[0]}" ]
@@ -264,7 +264,7 @@ REGEX_VERSION_CHECK="(^|\s)+(docxBox v)\K([0-9]|\.)*(?=\s|$)"
   check_for_valgrind_error
 }
 
-@test "\"docxbox h zpc\" displays help for zpc command" {
+@test "Case 31: \"docxbox h zpc\" displays help for zpc command" {
   pattern="Command: zpc - Compress XML, than create DOCX from files:"
 
   run ${DOCXBOX_BINARY} h zpc

--- a/test/functional/lorem.bats.sh
+++ b/test/functional/lorem.bats.sh
@@ -22,7 +22,7 @@ BASE_COMMAND="docxbox lorem filename.docx"
 
 ERR_LOG="test/tmp/err.log"
 
-@test "Exit code of \"${BASE_COMMAND}\" is zero" {
+@test "Case 1: Exit code of \"${BASE_COMMAND}\" is zero" {
   path_docx="test/tmp/cp_table_unordered_list_images.docx"
 
   run ${DOCXBOX_BINARY} lorem "${path_docx}"
@@ -31,7 +31,7 @@ ERR_LOG="test/tmp/err.log"
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lorem {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox lorem {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Filename of DOCX to be extracted"
 
   run ${DOCXBOX_BINARY} lorem
@@ -41,7 +41,7 @@ ERR_LOG="test/tmp/err.log"
   check_for_valgrind_error
 }
 
-@test "With \"${BASE_COMMAND}\" text gets replaced by dummy text" {
+@test "Case 3: With \"${BASE_COMMAND}\" text gets replaced by dummy text" {
   path_docx="test/tmp/cp_table_unordered_list_images.docx"
   pattern="Culpa ad eiusmod"
 
@@ -53,7 +53,7 @@ ERR_LOG="test/tmp/err.log"
   ${DOCXBOX_BINARY} txt "${path_docx}" | grep --invert-match --count "${pattern}"
 }
 
-title="With \"${BASE_COMMAND} newFilename.docx\" "
+title="Case 4: With \"${BASE_COMMAND} newFilename.docx\" "
 title+="text gets replaced by dummy text and is saved to new file"
 @test "${title}" {
   path_docx_1="test/tmp/cp_table_unordered_list_images.docx"
@@ -66,7 +66,7 @@ title+="text gets replaced by dummy text and is saved to new file"
   ls test/tmp | grep -c lorem.docx
 }
 
-@test "Output of \"docxbox lorem nonexistent.docx\" is an error message" {
+@test "Case 5: Output of \"docxbox lorem nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} lorem nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -76,7 +76,7 @@ title+="text gets replaced by dummy text and is saved to new file"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox lorem wrong_file_type\" is an error message" {
+@test "Case 6: Output of \"docxbox lorem wrong_file_type\" is an error message" {
   pattern="docxBox Error - File is no ZIP archive:"
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"

--- a/test/functional/ls.bats.sh
+++ b/test/functional/ls.bats.sh
@@ -24,14 +24,14 @@ PATH_NEW_DOCX="test/tmp/changedFile.docx"
 
 ERR_LOG="test/tmp/err.log"
 
-@test "Exit code of ${BASE_COMMAND}\" is zero" {
+@test "Case 1: Exit code of ${BASE_COMMAND}\" is zero" {
   run ${DOCXBOX_BINARY} ls "${PATH_DOCX}"
   [ "$status" -eq 0 ]
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox ls {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox ls {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} ls
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: DOCX filename" = "${lines[0]}" ]
@@ -39,7 +39,7 @@ ERR_LOG="test/tmp/err.log"
   check_for_valgrind_error
 }
 
-@test "Output of ${BASE_COMMAND}\" contains files' and directories' attributes" {
+@test "Case 3: Output of ${BASE_COMMAND}\" contains files' and directories' attributes" {
   attributes=(
   "Length"
   "Date"
@@ -53,7 +53,7 @@ ERR_LOG="test/tmp/err.log"
   done
 }
 
-@test "Output of ${BASE_COMMAND}\" is contained files" {
+@test "Case 4: Output of ${BASE_COMMAND}\" is contained files" {
 search_values=(
 "[Content_Types].xml"
 "_rels/.rels"
@@ -77,13 +77,13 @@ search_values=(
   done
 }
 
-@test "Output of ${BASE_COMMAND}\" contains amount of contained files" {
+@test "Case 5: Output of ${BASE_COMMAND}\" contains amount of contained files" {
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" | grep --count '14 files'
 
   check_for_valgrind_error
 }
 
-@test "Output of ${BASE_COMMAND}\" contains files' date and time" {
+@test "Case 6: Output of ${BASE_COMMAND}\" contains files' date and time" {
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" | grep --count "7/3/2020"
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" | grep --count "7/3/2020"
 
@@ -91,14 +91,14 @@ search_values=(
 }
 
 long_description="contains files with the given file ending"
-@test "Output of ${BASE_COMMAND} *.file-ending\" ${long_description}" {
+@test "Case 7: Output of ${BASE_COMMAND} *.file-ending\" ${long_description}" {
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" *.jpeg | grep --count "image2.jpeg"
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" *.xml | grep --count "10 files"
 
   check_for_valgrind_error
 }
 
-@test "With \"${BASE_COMMAND} changedFile.docx\" a side-by-side comparison is displayed" {
+@test "Case 8: With \"${BASE_COMMAND} changedFile.docx\" a side-by-side comparison is displayed" {
   run ${DOCXBOX_BINARY} lorem "${PATH_DOCX}" "${PATH_NEW_DOCX}"
 
   amount_chars_base=$(${DOCXBOX_BINARY} ls "${PATH_DOCX}" | wc --bytes)
@@ -109,7 +109,7 @@ long_description="contains files with the given file ending"
   check_for_valgrind_error
 }
 
-@test "Output of ${BASE_COMMAND} nonexistent.docx\" is an error message" {
+@test "Case 9: Output of ${BASE_COMMAND} nonexistent.docx\" is an error message" {
   run "$BATS_TEST_DIRNAME"/docxbox ls nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -119,7 +119,7 @@ long_description="contains files with the given file ending"
   check_for_valgrind_error
 }
 
-@test "Output of ${BASE_COMMAND} wrong_file_type\" is an error message" {
+@test "Case 10: Output of ${BASE_COMMAND} wrong_file_type\" is an error message" {
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
   "test/tmp/cp_mock_csv.csv"

--- a/test/functional/lsd.bats.sh
+++ b/test/functional/lsd.bats.sh
@@ -26,14 +26,14 @@ ERR_LOG="test/tmp/err.log"
 MERGE_FIELD="MERGEFIELD"
 MERGE_FORMAT="\* MERGEFORMAT"
 
-@test "Exit code of ${BASE_COMMAND} filename.docx\" is zero" {
+@test "Case 1: Exit code of ${BASE_COMMAND} filename.docx\" is zero" {
   run ${DOCXBOX_BINARY} lsd "${PATH_DOCX}"
   [ "$status" -eq 0 ]
 
   check_for_valgrind_error
 }
 
-@test "Output of ${BASE_COMMAND} {missing argument}\" is an error message" {
+@test "Case 2: Output of ${BASE_COMMAND} {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} lsd
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: Filename of DOCX to be extracted" = "${lines[0]}" ]
@@ -41,26 +41,26 @@ MERGE_FORMAT="\* MERGEFORMAT"
   check_for_valgrind_error
 }
 
-@test "With ${BASE_COMMAND} filename.docx\" the fields in the docx are listed" {
+@test "Case 3: With ${BASE_COMMAND} filename.docx\" the fields in the docx are listed" {
   ${DOCXBOX_BINARY} lsd "${PATH_DOCX}" | grep --count "${MERGE_FIELD}"
   ${DOCXBOX_BINARY} lsd "${PATH_DOCX}" | grep --count "${MERGE_FORMAT}"
 
   check_for_valgrind_error
 }
 
-@test "With ${BASE_COMMAND} filename.docx\" the fields in the header are listed" {
+@test "Case 4: With ${BASE_COMMAND} filename.docx\" the fields in the header are listed" {
   ${DOCXBOX_BINARY} lsd "${PATH_DOCX}" | grep --count "MERGEFIELD  Mergefield_Header"
 
   check_for_valgrind_error
 }
 
-@test "With ${BASE_COMMAND} filename.docx\" the fields in the footer are listed" {
+@test "Case 5: With ${BASE_COMMAND} filename.docx\" the fields in the footer are listed" {
   ${DOCXBOX_BINARY} lsd "${PATH_DOCX}" | grep --count "MERGEFIELD  Mergefield_Footer"
 
   check_for_valgrind_error
 }
 
-title="With \"docxbox ls filename.docx --fields\" "
+title="Case 6: With \"docxbox ls filename.docx --fields\" "
 title+="the fields in the docx are listed"
 @test "$title" {
   ${DOCXBOX_BINARY} lsd "${PATH_DOCX}" | grep --count "${MERGE_FIELD}"
@@ -69,14 +69,14 @@ title+="the fields in the docx are listed"
   check_for_valgrind_error
 }
 
-@test "With \"docxbox ls filename.docx -d\" the fields in the docx are listed" {
+@test "Case 7: With \"docxbox ls filename.docx -d\" the fields in the docx are listed" {
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" -d | grep --count "${MERGE_FIELD}"
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" -d | grep --count "${MERGE_FORMAT}"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsd nonexistent.docx\" is an error message" {
+@test "Case 8: Output of \"docxbox lsd nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} lsd nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -86,7 +86,7 @@ title+="the fields in the docx are listed"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of ${BASE_COMMAND} wrong_file_type\" is an error message" {
+@test "Case 9: Output of ${BASE_COMMAND} wrong_file_type\" is an error message" {
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
   "test/tmp/cp_mock_csv.csv"

--- a/test/functional/lsdj.bats.sh
+++ b/test/functional/lsdj.bats.sh
@@ -25,14 +25,14 @@ ERR_LOG="test/tmp/err.log"
 
 LONG_DESCRIPTION_JSON="the fields in the docx are listed as JSON"
 
-@test "Exit code of \"${BASE_COMMAND}\" is zero" {
+@test "Case 1: Exit code of \"${BASE_COMMAND}\" is zero" {
   run ${DOCXBOX_BINARY} lsdj "${PATH_DOCX}"
   [ "$status" -eq 0 ]
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsdj {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox lsdj {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} lsdj
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: Filename of DOCX to be extracted" = "${lines[0]}" ]
@@ -40,7 +40,7 @@ LONG_DESCRIPTION_JSON="the fields in the docx are listed as JSON"
   check_for_valgrind_error
 }
 
-@test "With \"${BASE_COMMAND}\" the fields in the docx are listed as JSON" {
+@test "Case 3: With \"${BASE_COMMAND}\" the fields in the docx are listed as JSON" {
   pattern="table_unordered_list_images.docx-"
   ${DOCXBOX_BINARY} lsdj "${PATH_DOCX}" | grep --count "${pattern}"
 
@@ -53,7 +53,7 @@ LONG_DESCRIPTION_JSON="the fields in the docx are listed as JSON"
 }
 
 longhand="--fields --json"
-title="With \"docxbox ls filename.docx ${longhand}\" "
+title="Case 4: With \"docxbox ls filename.docx ${longhand}\" "
 title+="${LONG_DESCRIPTION_JSON}"
 @test "${title}" {
   pattern="table_unordered_list_images.docx-"
@@ -67,7 +67,7 @@ title+="${LONG_DESCRIPTION_JSON}"
   check_for_valgrind_error
 }
 
-@test "With \"docxbox ls filename.docx -dj\" ${LONG_DESCRIPTION_JSON}" {
+@test "Case 5: With \"docxbox ls filename.docx -dj\" ${LONG_DESCRIPTION_JSON}" {
   pattern="table_unordered_list_images.docx-"
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" -dj | grep --count "${pattern}"
 
@@ -77,7 +77,7 @@ title+="${LONG_DESCRIPTION_JSON}"
   check_for_valgrind_error
 }
 
-@test "With \"docxbox lsd filename.docx --json\" ${LONG_DESCRIPTION_JSON}" {
+@test "Case 6: With \"docxbox lsd filename.docx --json\" ${LONG_DESCRIPTION_JSON}" {
   pattern="table_unordered_list_images.docx-"
   ${DOCXBOX_BINARY} lsd "${PATH_DOCX}" --json | grep --count "${pattern}"
 
@@ -89,7 +89,7 @@ title+="${LONG_DESCRIPTION_JSON}"
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsdj nonexistent.docx\" is an error message" {
+@test "Case 7: Output of \"docxbox lsdj nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} lsdj nonexistent.docx
   [ "$status" -ne 0 ]
   check_for_valgrind_error
@@ -98,7 +98,7 @@ title+="${LONG_DESCRIPTION_JSON}"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"${BASE_COMMAND} wrong_file_type\" is an error message" {
+@test "Case 8: Output of \"${BASE_COMMAND} wrong_file_type\" is an error message" {
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
   "test/tmp/cp_mock_csv.csv"

--- a/test/functional/lsf.bats.sh
+++ b/test/functional/lsf.bats.sh
@@ -24,14 +24,14 @@ ERR_LOG="test/tmp/err.log"
 BASE_COMMAND="docxbox lsf filename.docx"
 LONGHAND_COMMAND="docxbox ls filename.docx"
 
-@test "Exit code of \"${BASE_COMMAND}\" is zero" {
+@test "Case 1: Exit code of \"${BASE_COMMAND}\" is zero" {
   run ${DOCXBOX_BINARY} lsf "${PATH_DOCX}"
   [ "$status" -eq 0 ]
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsf {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox lsf {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Filename of DOCX to be extracted"
 
   run ${DOCXBOX_BINARY} lsf
@@ -41,7 +41,7 @@ LONGHAND_COMMAND="docxbox ls filename.docx"
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains ground informations" {
+@test "Case 3: Output of \"${BASE_COMMAND}\" contains ground informations" {
   run ${DOCXBOX_BINARY} lsf "${PATH_DOCX}"
   [ "$status" -eq 0 ]
   [ "word/fontTable.xml lists 10 fonts:" = "${lines[0]}" ]
@@ -49,7 +49,7 @@ LONGHAND_COMMAND="docxbox ls filename.docx"
   check_for_valgrind_error
 }
 
-@test "Output of \"${LONGHAND_COMMAND} --fonts\" contains ground informations" {
+@test "Case 4: Output of \"${LONGHAND_COMMAND} --fonts\" contains ground informations" {
   run ${DOCXBOX_BINARY} ls "${PATH_DOCX}" --fonts
   [ "$status" -eq 0 ]
   [ "word/fontTable.xml lists 10 fonts:" = "${lines[0]}" ]
@@ -57,7 +57,7 @@ LONGHAND_COMMAND="docxbox ls filename.docx"
   check_for_valgrind_error
 }
 
-@test "Output of \"${LONGHAND_COMMAND} -f\" contains ground informations" {
+@test "Case 5: Output of \"${LONGHAND_COMMAND} -f\" contains ground informations" {
   run ${DOCXBOX_BINARY} ls "${PATH_DOCX}" -f
   [ "$status" -eq 0 ]
   [ "word/fontTable.xml lists 10 fonts:" = "${lines[0]}" ]
@@ -65,7 +65,7 @@ LONGHAND_COMMAND="docxbox ls filename.docx"
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains files' and directories' attributes" {
+@test "Case 6: Output of \"${BASE_COMMAND}\" contains files' and directories' attributes" {
   attributes=(
   "Font"
   "AltName"
@@ -80,19 +80,19 @@ LONGHAND_COMMAND="docxbox ls filename.docx"
   done
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains fontfile-filename" {
+@test "Case 7: Output of \"${BASE_COMMAND}\" contains fontfile-filename" {
   ${DOCXBOX_BINARY} lsf "${PATH_DOCX}" | grep --count "fontTable.xml"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains amount fonts" {
+@test "Case 8: Output of \"${BASE_COMMAND}\" contains amount fonts" {
   ${DOCXBOX_BINARY} lsf "${PATH_DOCX}" | grep --count "10 fonts"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains font names" {
+@test "Case 9: Output of \"${BASE_COMMAND}\" contains font names" {
   font_names=(
     "Calibri
     Times New Roman
@@ -110,19 +110,19 @@ LONGHAND_COMMAND="docxbox ls filename.docx"
   done
 }
 
-@test "Output of \"${BASE_COMMAND}\" can contain alternative font names" {
+@test "Case 10: Output of \"${BASE_COMMAND}\" can contain alternative font names" {
   ${DOCXBOX_BINARY} lsf "${PATH_DOCX}" | grep --count "宋体"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains font-charSets" {
+@test "Case 11: Output of \"${BASE_COMMAND}\" contains font-charSets" {
   ${DOCXBOX_BINARY} lsf "${PATH_DOCX}" | grep --count "00"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains font-family" {
+@test "Case 12: Output of \"${BASE_COMMAND}\" contains font-family" {
   font_family=(
   "roman"
   "swiss"
@@ -135,13 +135,13 @@ LONGHAND_COMMAND="docxbox ls filename.docx"
   done
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains font-pitch" {
+@test "Case 13: Output of \"${BASE_COMMAND}\" contains font-pitch" {
   ${DOCXBOX_BINARY} lsf "${PATH_DOCX}" | grep --count "variable"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsf nonexistent.docx\" is an error message" {
+@test "Case 14: Output of \"docxbox lsf nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} lsf nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -151,7 +151,7 @@ LONGHAND_COMMAND="docxbox ls filename.docx"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox lsf wrong_file_type\" is an error message" {
+@test "Case 15: Output of \"docxbox lsf wrong_file_type\" is an error message" {
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
   "test/tmp/cp_mock_csv.csv"

--- a/test/functional/lsfj.bats.sh
+++ b/test/functional/lsfj.bats.sh
@@ -33,14 +33,14 @@ ATTRIBUTES=(
   "family"
   "pitch")
 
-@test "Exit code of \"docxbox ls filename.docx\" is zero" {
+@test "Case 1: Exit code of \"docxbox ls filename.docx\" is zero" {
   run ${DOCXBOX_BINARY} lsfj "${PATH_DOCX}"
   [ "$status" -eq 0 ]
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsfj {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox lsfj {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} lsfj
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: Filename of DOCX to be extracted" = "${lines[0]}" ]
@@ -48,7 +48,7 @@ ATTRIBUTES=(
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" ${LONG_DESCRIPTION}" {
+@test "Case 3: Output of \"${BASE_COMMAND}\" ${LONG_DESCRIPTION}" {
   for i in "${ATTRIBUTES[@]}"
   do
     ${DOCXBOX_BINARY} lsfj "${PATH_DOCX}" | grep --count "${i}"
@@ -56,7 +56,7 @@ ATTRIBUTES=(
   done
 }
 
-@test "Output of \"${LONGHAND_COMMAND} --json\" ${LONG_DESCRIPTION}" {
+@test "Case 4: Output of \"${LONGHAND_COMMAND} --json\" ${LONG_DESCRIPTION}" {
   for i in "${ATTRIBUTES[@]}"
   do
     ${DOCXBOX_BINARY} lsf "${PATH_DOCX}" --json | grep --count "${i}"
@@ -64,7 +64,7 @@ ATTRIBUTES=(
   done
 }
 
-@test "Output of \"${LONGHAND_COMMAND} -j\" ${LONG_DESCRIPTION}" {
+@test "Case 5: Output of \"${LONGHAND_COMMAND} -j\" ${LONG_DESCRIPTION}" {
   for i in "${ATTRIBUTES[@]}"
   do
     ${DOCXBOX_BINARY} lsf "${PATH_DOCX}" -j | grep --count "${i}"
@@ -73,7 +73,7 @@ ATTRIBUTES=(
 }
 
 LONGHAND="--fonts --json"
-@test "Output of \"docxbox ls filename.docx ${LONGHAND}\" ${LONG_DESCRIPTION}" {
+@test "Case 6: Output of \"docxbox ls filename.docx ${LONGHAND}\" ${LONG_DESCRIPTION}" {
   for i in "${ATTRIBUTES[@]}"
   do
     ${DOCXBOX_BINARY} ls "${PATH_DOCX}" ${LONGHAND} | grep --count "${i}"
@@ -81,7 +81,7 @@ LONGHAND="--fonts --json"
   done
 }
 
-@test "Output of \"docxbox ls filename.docx -fj\" ${LONG_DESCRIPTION}" {
+@test "Case 7: Output of \"docxbox ls filename.docx -fj\" ${LONG_DESCRIPTION}" {
   for i in "${ATTRIBUTES[@]}"
   do
     ${DOCXBOX_BINARY} ls "${PATH_DOCX}" -fj | grep --count "${i}"
@@ -89,13 +89,13 @@ LONGHAND="--fonts --json"
   done
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains fontfile-filename" {
+@test "Case 8: Output of \"${BASE_COMMAND}\" contains fontfile-filename" {
   ${DOCXBOX_BINARY} lsfj "${PATH_DOCX}" | grep --count "fontTable.xml"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains font names" {
+@test "Case 9: Output of \"${BASE_COMMAND}\" contains font names" {
   font_names=(
     "Calibri
     Times New Roman
@@ -113,19 +113,19 @@ LONGHAND="--fonts --json"
   done
 }
 
-@test "Output of \"${BASE_COMMAND}\" can contain alternative font names" {
+@test "Case 10: Output of \"${BASE_COMMAND}\" can contain alternative font names" {
   ${DOCXBOX_BINARY} lsfj "${PATH_DOCX}" | grep --count "宋体"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains font-charSets" {
+@test "Case 11: Output of \"${BASE_COMMAND}\" contains font-charSets" {
   ${DOCXBOX_BINARY} lsfj "${PATH_DOCX}" | grep --count "00"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains font-family" {
+@test "Case 12: Output of \"${BASE_COMMAND}\" contains font-family" {
   font_family=(
   "roman"
   "swiss"
@@ -138,13 +138,13 @@ LONGHAND="--fonts --json"
   done
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains font-pitch" {
+@test "Case 13: Output of \"${BASE_COMMAND}\" contains font-pitch" {
   ${DOCXBOX_BINARY} lsfj "${PATH_DOCX}" | grep --count "variable"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsfj nonexistent.docx\" is an error message" {
+@test "Case 14: Output of \"docxbox lsfj nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} lsfj nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -154,7 +154,7 @@ LONGHAND="--fonts --json"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox lsfj wrong_file_type\" is an error message" {
+@test "Case 15: Output of \"docxbox lsfj wrong_file_type\" is an error message" {
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
   "test/tmp/cp_mock_csv.csv"

--- a/test/functional/lsi.bats.sh
+++ b/test/functional/lsi.bats.sh
@@ -23,14 +23,14 @@ ERR_LOG="test/tmp/err.log"
 
 BASE_COMMAND="docxbox lsi filename.docx"
 
-@test "Exit code of \"${BASE_COMMAND}\" is zero" {
+@test "Case 1: Exit code of \"${BASE_COMMAND}\" is zero" {
   run ${DOCXBOX_BINARY} lsi "${PATH_DOCX}"
   [ "$status" -eq 0 ]
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsi {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox lsi {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Filename of DOCX to be extracted"
 
   run ${DOCXBOX_BINARY} lsi
@@ -40,7 +40,7 @@ BASE_COMMAND="docxbox lsi filename.docx"
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains files' and directories' attributes" {
+@test "Case 3: Output of \"${BASE_COMMAND}\" contains files' and directories' attributes" {
   attributes=(
   "Length"
   "Date"
@@ -54,7 +54,7 @@ BASE_COMMAND="docxbox lsi filename.docx"
   done
 }
 
-@test "Output of \"${BASE_COMMAND}\" is contained images" {
+@test "Case 4: Output of \"${BASE_COMMAND}\" is contained images" {
   run ${DOCXBOX_BINARY} lsi "${PATH_DOCX}"
   [ "$status" -eq 0 ]
   ${DOCXBOX_BINARY} lsi "${PATH_DOCX}" | grep --count "image2.jpeg"
@@ -62,19 +62,19 @@ BASE_COMMAND="docxbox lsi filename.docx"
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox ls filename.docx -i\" is contained images" {
+@test "Case 5: Output of \"docxbox ls filename.docx -i\" is contained images" {
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" -i | grep --count "image2.jpeg"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox ls filename.docx --images\" is contained images" {
+@test "Case 6: Output of \"docxbox ls filename.docx --images\" is contained images" {
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" --images | grep --count "image2.jpeg"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsi nonexistent.docx\" is an error message" {
+@test "Case 7: Output of \"docxbox lsi nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} lsi nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -84,7 +84,7 @@ BASE_COMMAND="docxbox lsi filename.docx"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox lsi wrong_file_type\" is an error message" {
+@test "Case 8: Output of \"docxbox lsi wrong_file_type\" is an error message" {
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
   "test/tmp/cp_mock_csv.csv"

--- a/test/functional/lsij.bats.sh
+++ b/test/functional/lsij.bats.sh
@@ -24,14 +24,14 @@ ERR_LOG="test/tmp/err.log"
 BASE_COMMAND="docxbox lsij filename.docx"
 DESCRIPTION="are contained images as JSON"
 
-@test "Exit code of \"${BASE_COMMAND}\" is zero" {
+@test "Case 1: Exit code of \"${BASE_COMMAND}\" is zero" {
   run ${DOCXBOX_BINARY} lsij "${PATH_DOCX}"
   [ "$status" -eq 0 ]
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsij {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox lsij {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} lsij
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: DOCX filename" = "${lines[0]}" ]
@@ -39,37 +39,37 @@ DESCRIPTION="are contained images as JSON"
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" is contained images as JSON" {
+@test "Case 3: Output of \"${BASE_COMMAND}\" is contained images as JSON" {
   ${DOCXBOX_BINARY} lsij "${PATH_DOCX}" | grep --count "image2.jpeg"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsi filename.docx --json\" ${DESCRIPTION}" {
+@test "Case 4: Output of \"docxbox lsi filename.docx --json\" ${DESCRIPTION}" {
   ${DOCXBOX_BINARY} lsi "${PATH_DOCX}" --json | grep --count "image2.jpeg"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsi filename.docx -j\" ${DESCRIPTION}" {
+@test "Case 5: Output of \"docxbox lsi filename.docx -j\" ${DESCRIPTION}" {
   ${DOCXBOX_BINARY} lsi "${PATH_DOCX}" -j | grep --count "image2.jpeg"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox ls filename.docx -ij\" ${DESCRIPTION}" {
+@test "Case 6: Output of \"docxbox ls filename.docx -ij\" ${DESCRIPTION}" {
   ${DOCXBOX_BINARY} lsi "${PATH_DOCX}" -ij | grep --count "image2.jpeg"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox ls filename.docx --images --json\" ${DESCRIPTION}" {
+@test "Case 7: Output of \"docxbox ls filename.docx --images --json\" ${DESCRIPTION}" {
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" --images --json | grep --count "image2.jpeg"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsij nonexistent.docx\" is an error message" {
+@test "Case 8: Output of \"docxbox lsij nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} lsij nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -79,7 +79,7 @@ DESCRIPTION="are contained images as JSON"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox lsij wrong_file_type\" is an error message" {
+@test "Case 9: Output of \"docxbox lsij wrong_file_type\" is an error message" {
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
   "test/tmp/cp_mock_csv.csv"

--- a/test/functional/lsj.bats.sh
+++ b/test/functional/lsj.bats.sh
@@ -30,7 +30,7 @@ ATTRIBUTES=(
   "time"
   "file")
 
-@test "Output of \"docxbox lsj filename.docx\" ${DESCRIPTION}" {
+@test "Case 1: Output of \"docxbox lsj filename.docx\" ${DESCRIPTION}" {
   for i in "${ATTRIBUTES[@]}"
   do
     ${DOCXBOX_BINARY} lsj "${PATH_DOCX}" | grep --count "${i}"
@@ -38,7 +38,7 @@ ATTRIBUTES=(
   done
 }
 
-@test "Output of \"${LONGHAND_COMMAND} --json\" ${DESCRIPTION}" {
+@test "Case 2: Output of \"${LONGHAND_COMMAND} --json\" ${DESCRIPTION}" {
   for i in "${ATTRIBUTES[@]}"
   do
     ${DOCXBOX_BINARY} ls "${PATH_DOCX}" --json | grep --count "${i}"
@@ -46,7 +46,7 @@ ATTRIBUTES=(
   done
 }
 
-@test "Output of \"${LONGHAND_COMMAND} -j\" ${DESCRIPTION}" {
+@test "Case 3: Output of \"${LONGHAND_COMMAND} -j\" ${DESCRIPTION}" {
   for i in "${ATTRIBUTES[@]}"
   do
     ${DOCXBOX_BINARY} ls "${PATH_DOCX}" -j | grep --count "${i}"
@@ -54,7 +54,7 @@ ATTRIBUTES=(
   done
 }
 
-@test "Output of \"docxbox lsj filename.docx\" are contained files" {
+@test "Case 4: Output of \"docxbox lsj filename.docx\" are contained files" {
 search_values=(
 "[Content_Types].xml"
 "_rels/.rels"
@@ -78,14 +78,14 @@ search_values=(
   done
 }
 
-@test "Output of \"docxbox lsj filename.docx\" contains files' date and time" {
+@test "Case 5: Output of \"docxbox lsj filename.docx\" contains files' date and time" {
   ${DOCXBOX_BINARY} lsj "${PATH_DOCX}" | grep --count "7/./2020"
   ${DOCXBOX_BINARY} lsj "${PATH_DOCX}" | grep --count "7/3/2020"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsj {missing argument}\" is an error message" {
+@test "Case 6: Output of \"docxbox lsj {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} lsj
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: DOCX filename" = "${lines[0]}" ]
@@ -93,7 +93,7 @@ search_values=(
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsj nonexistent.docx\" is an error message" {
+@test "Case 7: Output of \"docxbox lsj nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} lsj nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -103,7 +103,7 @@ search_values=(
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox lsj wrong_file_type\" is an error message" {
+@test "Case 8: Output of \"docxbox lsj wrong_file_type\" is an error message" {
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
   "test/tmp/cp_mock_csv.csv"

--- a/test/functional/lsl.bats.sh
+++ b/test/functional/lsl.bats.sh
@@ -36,14 +36,14 @@ SEARCH_RESULTS=(
 
 REGEX_RESULT="docProps/core.xml"
 
-@test "Exit code of \"${BASE_COMMAND}\" is zero" {
+@test "Case 1: Exit code of \"${BASE_COMMAND}\" is zero" {
   run ${DOCXBOX_BINARY} lsl "${PATH_DOCX}" fonts
   [ "$status" -eq 0 ]
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsl {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox lsl {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} lsl
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: DOCX filename" = "${lines[0]}" ]
@@ -51,7 +51,7 @@ REGEX_RESULT="docProps/core.xml"
   check_for_valgrind_error
 }
 
-title="Output of \"docxbox lsl filename.docx {missing argument}\" "
+title="Case 3: Output of \"docxbox lsl filename.docx {missing argument}\" "
 title+="is an error message"
 @test "${title}" {
   pattern="docxBox Error - Missing argument: "
@@ -64,7 +64,7 @@ title+="is an error message"
   check_for_valgrind_error
 }
 
-@test "\"${BASE_COMMAND}\" ${DESCRIPTION}" {
+@test "Case 4: \"${BASE_COMMAND}\" ${DESCRIPTION}" {
   for i in "${SEARCH_RESULTS[@]}"
   do
     ${DOCXBOX_BINARY} lsl "${PATH_DOCX}" fonts | grep --count "${i}"
@@ -72,7 +72,7 @@ title+="is an error message"
   done
 }
 
-@test "\"docxbox ls filename.docx -l searchString\" ${DESCRIPTION}" {
+@test "Case 4: \"docxbox ls filename.docx -l searchString\" ${DESCRIPTION}" {
   for i in "${SEARCH_RESULTS[@]}"
   do
     ${DOCXBOX_BINARY} ls "${PATH_DOCX}" -l fonts | grep --count "${i}"
@@ -80,7 +80,7 @@ title+="is an error message"
   done
 }
 
-@test "\"docxbox ls filename.docx --locate searchString\" ${DESCRIPTION}" {
+@test "Case 5: \"docxbox ls filename.docx --locate searchString\" ${DESCRIPTION}" {
   for i in "${SEARCH_RESULTS[@]}"
   do
     ${DOCXBOX_BINARY} lsl "${PATH_DOCX}" --locate fonts | grep --count "${i}"
@@ -88,25 +88,25 @@ title+="is an error message"
   done
 }
 
-@test "With \"docxbox lsl filename.docx REGEX\" ${REGEX_DESCRIPTION}" {
+@test "Case 6: With \"docxbox lsl filename.docx REGEX\" ${REGEX_DESCRIPTION}" {
   ${DOCXBOX_BINARY} lsl "${PATH_DOCX}" "${REGEX}" | grep --count ${REGEX_RESULT}
 
   check_for_valgrind_error
 }
 
-@test "With \"docxbox ls filename.docx -l REGEX\" ${REGEX_DESCRIPTION}" {
+@test "Case 7: With \"docxbox ls filename.docx -l REGEX\" ${REGEX_DESCRIPTION}" {
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" -l "${REGEX}" | grep --count ${REGEX_RESULT}
 
   check_for_valgrind_error
 }
 
-@test "With \"docxbox ls filename.docx --locate REGEX\" ${REGEX_DESCRIPTION}" {
+@test "Case 8: With \"docxbox ls filename.docx --locate REGEX\" ${REGEX_DESCRIPTION}" {
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" --locate "${REGEX}" | grep --count ${REGEX_RESULT}
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsl nonexistent.docx searchString\" is an error message" {
+@test "Case 9: Output of \"docxbox lsl nonexistent.docx searchString\" is an error message" {
   run ${DOCXBOX_BINARY} lsl nonexistent.docx fonts
   [ "$status" -ne 0 ]
 
@@ -116,7 +116,7 @@ title+="is an error message"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox lsl wrong_file_type\" is an error message" {
+@test "Case 10: Output of \"docxbox lsl wrong_file_type\" is an error message" {
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
   "test/tmp/cp_mock_csv.csv"

--- a/test/functional/lslj.bats.sh
+++ b/test/functional/lslj.bats.sh
@@ -27,7 +27,7 @@ SEARCH_RESULTS=(
 "\"file\":\"word/numbering.xml\""
 "\"file\":\"word/styles.xml\"")
 
-@test "Output of \"docxbox lslj {missing argument}\" ${error_message}" {
+@test "Case 1: Output of \"docxbox lslj {missing argument}\" ${error_message}" {
   run ${DOCXBOX_BINARY} lslj
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: DOCX filename" = "${lines[0]}" ]
@@ -35,7 +35,7 @@ SEARCH_RESULTS=(
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lslj filename.docx {missing argument} ${error_message}" {
+@test "Case 2: Output of \"docxbox lslj filename.docx {missing argument} ${error_message}" {
   pattern="docxBox Error - Missing argument: "
   pattern+="String or regular expression to be located"
 
@@ -46,7 +46,7 @@ SEARCH_RESULTS=(
   check_for_valgrind_error
 }
 
-@test "\"docxbox lslj filename.docx searchString\" ${description}" {
+@test "Case 3: \"docxbox lslj filename.docx searchString\" ${description}" {
   for i in "${SEARCH_RESULTS[@]}"
   do
     ${DOCXBOX_BINARY} lslj "${PATH_DOCX}" fonts | grep -c "${i}"
@@ -54,7 +54,7 @@ SEARCH_RESULTS=(
   done
 }
 
-@test "\"docxbox lsl filename.docx -j searchString\" ${description}" {
+@test "Case 4: \"docxbox lsl filename.docx -j searchString\" ${description}" {
   for i in "${SEARCH_RESULTS[@]}"
   do
     ${DOCXBOX_BINARY} lsl "${PATH_DOCX}" -j fonts | grep -c "${i}"
@@ -62,7 +62,7 @@ SEARCH_RESULTS=(
   done
 }
 
-@test "\"docxbox lsl filename.docx --json searchString\" ${description}" {
+@test "Case 5: \"docxbox lsl filename.docx --json searchString\" ${description}" {
   for i in "${SEARCH_RESULTS[@]}"
   do
     ${DOCXBOX_BINARY} lsl "${PATH_DOCX}" --json fonts | grep -c "${i}"
@@ -70,7 +70,7 @@ SEARCH_RESULTS=(
   done
 }
 
-@test "\"docxbox ls filename.docx -lj searchString\" ${description}" {
+@test "Case 6: \"docxbox ls filename.docx -lj searchString\" ${description}" {
   for i in "${SEARCH_RESULTS[@]}"
   do
     ${DOCXBOX_BINARY} ls "${PATH_DOCX}" -lj fonts | grep -c "${i}"
@@ -78,7 +78,7 @@ SEARCH_RESULTS=(
   done
 }
 
-@test "\"docxbox ls filename.docx --locate -j searchString\" ${description}" {
+@test "Case 7: \"docxbox ls filename.docx --locate -j searchString\" ${description}" {
   for i in "${SEARCH_RESULTS[@]}"
   do
     ${DOCXBOX_BINARY} ls "${PATH_DOCX}" --locate -j fonts | grep -c "${i}"
@@ -86,7 +86,7 @@ SEARCH_RESULTS=(
   done
 }
 
-@test "\"docxbox ls filename.docx --locate --json searchString\" ${description}" {
+@test "Case 8: \"docxbox ls filename.docx --locate --json searchString\" ${description}" {
   for i in "${SEARCH_RESULTS[@]}"
   do
     ${DOCXBOX_BINARY} ls "${PATH_DOCX}" --locate --json fonts | grep -c "${i}"
@@ -94,7 +94,7 @@ SEARCH_RESULTS=(
   done
 }
 
-@test "Output of \"docxbox lslj nonexistent.docx searchString\" is an error message" {
+@test "Case 9: Output of \"docxbox lslj nonexistent.docx searchString\" is an error message" {
   run ${DOCXBOX_BINARY} lslj nonexistent.docx fonts
   [ "$status" -ne 0 ]
 
@@ -104,7 +104,7 @@ SEARCH_RESULTS=(
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox lslj wrong_file_type searchString\" ${error_message}" {
+@test "Case 10: Output of \"docxbox lslj wrong_file_type searchString\" ${error_message}" {
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
   "test/tmp/cp_mock_csv.csv"

--- a/test/functional/lsm.bats.sh
+++ b/test/functional/lsm.bats.sh
@@ -23,14 +23,14 @@ ERR_LOG="test/tmp/err.log"
 
 BASE_COMMAND="docxbox lsm filename.docx"
 
-@test "Exit code of \"${BASE_COMMAND}\" is zero" {
+@test "Case 1: Exit code of \"${BASE_COMMAND}\" is zero" {
   run ${DOCXBOX_BINARY} lsm "${PATH_DOCX}"
   [ "$status" -eq 0 ]
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsm {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox lsm {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} lsm
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: Filename of DOCX to be extracted" = "${lines[0]}" ]
@@ -38,7 +38,7 @@ BASE_COMMAND="docxbox lsm filename.docx"
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains information about the xml schema" {
+@test "Case 3: Output of \"${BASE_COMMAND}\" contains information about the xml schema" {
   xml_schema="xmlSchema: http://schemas.openxmlformats.org/officeDocument/2006"
 
   ${DOCXBOX_BINARY} lsm "${PATH_DOCX}" | grep --count "${xml_schema}"
@@ -46,7 +46,7 @@ BASE_COMMAND="docxbox lsm filename.docx"
   check_for_valgrind_error
 }
 
-title="Output of \"${BASE_COMMAND}\" "
+title="Case 4: Output of \"${BASE_COMMAND}\" "
 title+="contains information about the creation time and date"
 @test "${title}" {
   created="created: 2020-06-18T10:30:11Z"
@@ -56,19 +56,19 @@ title+="contains information about the creation time and date"
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains language information" {
+@test "Case 5: Output of \"${BASE_COMMAND}\" contains language information" {
   ${DOCXBOX_BINARY} lsm "${PATH_DOCX}" | grep --count "language: en-US"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains information about the revision" {
+@test "Case 6: Output of \"${BASE_COMMAND}\" contains information about the revision" {
   ${DOCXBOX_BINARY} lsm "${PATH_DOCX}" | grep --count "revision: 2"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsm nonexistent.docx\" is an error message" {
+@test "Case 7: Output of \"docxbox lsm nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} lsm nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -78,7 +78,7 @@ title+="contains information about the creation time and date"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox lsm wrong_file_type\" is an error message" {
+@test "Case 8: Output of \"docxbox lsm wrong_file_type\" is an error message" {
   pattern="docxBox Error - File is no ZIP archive:"
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"

--- a/test/functional/lsmj.bats.sh
+++ b/test/functional/lsmj.bats.sh
@@ -27,14 +27,14 @@ DESCRIPTION="contains information about the creation time and date"
 
 PATTERN_CREATED="\"created\": \"2020-06-18T10:30:11Z\""
 
-@test "Exit code of \"${BASE_COMMAND}\" is zero" {
+@test "Case 1: Exit code of \"${BASE_COMMAND}\" is zero" {
   run ${DOCXBOX_BINARY} lsmj "${PATH_DOCX}"
   [ "$status" -eq 0 ]
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsmj {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox lsmj {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Filename of DOCX to be extracted"
 
   run ${DOCXBOX_BINARY} lsmj
@@ -44,7 +44,7 @@ PATTERN_CREATED="\"created\": \"2020-06-18T10:30:11Z\""
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains information about the xml schema" {
+@test "Case 3: Output of \"${BASE_COMMAND}\" contains information about the xml schema" {
   pattern="\"xmlSchema\": \"http://schemas.openxmlformats.org/officeDocument/2006\""
 
   ${DOCXBOX_BINARY} lsmj "${PATH_DOCX}" | grep --count "${pattern}"
@@ -52,31 +52,31 @@ PATTERN_CREATED="\"created\": \"2020-06-18T10:30:11Z\""
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsm filename.docx --json\" ${DESCRIPTION}" {
+@test "Case 4: Output of \"docxbox lsm filename.docx --json\" ${DESCRIPTION}" {
   ${DOCXBOX_BINARY} lsm "${PATH_DOCX}" --json | grep --count "${PATTERN_CREATED}"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsm filename.docx -j\" ${DESCRIPTION}" {
+@test "Case 5: Output of \"docxbox lsm filename.docx -j\" ${DESCRIPTION}" {
   ${DOCXBOX_BINARY} lsm "${PATH_DOCX}" -j | grep --count "${PATTERN_CREATED}"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox ls filename.docx --meta --json\" ${DESCRIPTION}" {
+@test "Case 6: Output of \"docxbox ls filename.docx --meta --json\" ${DESCRIPTION}" {
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" --meta --json | grep --count "${PATTERN_CREATED}"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox ls filename.docx -mj\" ${DESCRIPTION}" {
+@test "Case 7: Output of \"docxbox ls filename.docx -mj\" ${DESCRIPTION}" {
   ${DOCXBOX_BINARY} ls "${PATH_DOCX}" -mj | grep --count "${PATTERN_CREATED}"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains language information" {
+@test "Case 8: Output of \"${BASE_COMMAND}\" contains language information" {
   pattern="\"language\": \"en-US\""
 
   ${DOCXBOX_BINARY} lsmj "${PATH_DOCX}" | grep --count "${pattern}"
@@ -84,13 +84,13 @@ PATTERN_CREATED="\"created\": \"2020-06-18T10:30:11Z\""
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" contains information about the revision" {
+@test "Case 9: Output of \"${BASE_COMMAND}\" contains information about the revision" {
   ${DOCXBOX_BINARY} lsmj "${PATH_DOCX}" | grep --count "\"revision\": \"2\""
 
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox lsmj nonexistent.docx\" is an error message" {
+@test "Case 10: Output of \"docxbox lsmj nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} lsmj nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -100,7 +100,7 @@ PATTERN_CREATED="\"created\": \"2020-06-18T10:30:11Z\""
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox lsmj wrong_file_type\" is an error message" {
+@test "Case 11: Output of \"docxbox lsmj wrong_file_type\" is an error message" {
   pattern="docxBox Error - File is no ZIP archive:"
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"

--- a/test/functional/mm.bats.sh
+++ b/test/functional/mm.bats.sh
@@ -23,7 +23,7 @@ ERR_LOG="test/tmp/err.log"
 
 BASE_COMMAND="docxbox mm filename.docx"
 
-@test "Output of \"docxbox mm {missing argument}\" is an error message" {
+@test "Case 1: Output of \"docxbox mm {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} mm
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: DOCX filename" = "${lines[0]}" ]
@@ -31,7 +31,7 @@ BASE_COMMAND="docxbox mm filename.docx"
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND} {missing argument}\" is an error message" {
+@test "Case 2: Output of \"${BASE_COMMAND} {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Meta attribute to be set"
 
   run ${DOCXBOX_BINARY} mm "${PATH_DOCX}"
@@ -42,7 +42,7 @@ BASE_COMMAND="docxbox mm filename.docx"
 }
 
 title="the meta attribute \"title\" can be modified"
-@test "With \"${BASE_COMMAND} title {argument}\" ${title}" {
+@test "Case 3: With \"${BASE_COMMAND} title {argument}\" ${title}" {
   run ${DOCXBOX_BINARY} mm "${PATH_DOCX}" title "someTitle"
   [ "$status" -eq 0 ]
 
@@ -52,7 +52,7 @@ title="the meta attribute \"title\" can be modified"
 }
 
 creator="the meta attribute \"creator\" can be modified"
-@test "With \"${BASE_COMMAND} creator {argument}\" ${creator}" {
+@test "Case 4: With \"${BASE_COMMAND} creator {argument}\" ${creator}" {
   run ${DOCXBOX_BINARY} mm "${PATH_DOCX}" creator "John Doe"
   [ "$status" -eq 0 ]
 
@@ -62,7 +62,7 @@ creator="the meta attribute \"creator\" can be modified"
 }
 
 last_modified_by="the meta attribute \"lastModifiedBy\" can be modified"
-@test "With \"${BASE_COMMAND} lastModifiedBy {argument}\" ${last_modified_by}" {
+@test "Case 5: With \"${BASE_COMMAND} lastModifiedBy {argument}\" ${last_modified_by}" {
   pattern="lastModifiedBy: John Doe"
 
   run ${DOCXBOX_BINARY} mm "${PATH_DOCX}" lastModifiedBy "John Doe"
@@ -74,7 +74,7 @@ last_modified_by="the meta attribute \"lastModifiedBy\" can be modified"
 }
 
 last_printed="the meta attribute \"lastPrinted\" can be modified"
-@test "With \"${BASE_COMMAND} lastPrinted {argument}\" ${last_printed}" {
+@test "Case 6: With \"${BASE_COMMAND} lastPrinted {argument}\" ${last_printed}" {
   print_date="2020-02-20T10:31:00Z"
   pattern="lastPrinted: 2020-02-20T10:31:00Z"
 
@@ -87,7 +87,7 @@ last_printed="the meta attribute \"lastPrinted\" can be modified"
 }
 
 language="the meta attribute \"language\" can be modified"
-@test "With \"${BASE_COMMAND} language {argument}\" ${language}" {
+@test "Case 7: With \"${BASE_COMMAND} language {argument}\" ${language}" {
   run ${DOCXBOX_BINARY} mm "${PATH_DOCX}" language "de-CH"
   [ "$status" -eq 0 ]
 
@@ -97,7 +97,7 @@ language="the meta attribute \"language\" can be modified"
 }
 
 created="the meta attribute \"created\" can be modified"
-@test "With \"${BASE_COMMAND} created {argument}\" ${created}" {
+@test "Case 8: With \"${BASE_COMMAND} created {argument}\" ${created}" {
   pattern="created: 2020-10-20T10:20:00Z"
 
   run ${DOCXBOX_BINARY} mm "${PATH_DOCX}" created "2020-10-20T10:20:00Z"
@@ -109,7 +109,7 @@ created="the meta attribute \"created\" can be modified"
 }
 
 modified="the meta attribute \"modified\" can be modified"
-@test "With \"${BASE_COMMAND} modified {argument}\" ${modified}" {
+@test "Case 9: With \"${BASE_COMMAND} modified {argument}\" ${modified}" {
   pattern="modified: 2020-10-20T10:20:00Z"
 
   run ${DOCXBOX_BINARY} mm "${PATH_DOCX}" modified "2020-10-20T10:20:00Z"
@@ -120,7 +120,7 @@ modified="the meta attribute \"modified\" can be modified"
   ${DOCXBOX_BINARY} lsm "${PATH_DOCX}" | grep --count "${pattern}"
 }
 
-@test "Modifying the meta attribute \"created\" does not change the meta attribute \"modified\"" {
+@test "Case 10: Modifying the meta attribute \"created\" does not change the meta attribute \"modified\"" {
   created=$(${DOCXBOX_BINARY} lsm "${PATH_DOCX}" | grep "created")
 
   run ${DOCXBOX_BINARY} mm "${PATH_DOCX}" modified "2020-10-20T10:20:00Z"
@@ -132,7 +132,7 @@ modified="the meta attribute \"modified\" can be modified"
 }
 
 revision="the meta attribute \"revision\" can be changed"
-@test "With \"${BASE_COMMAND} revision {argument}\" ${revision}" {
+@test "Case 11: With \"${BASE_COMMAND} revision {argument}\" ${revision}" {
   run ${DOCXBOX_BINARY} mm "${PATH_DOCX}" revision "25"
   [ "$status" -eq 0 ]
 
@@ -142,7 +142,7 @@ revision="the meta attribute \"revision\" can be changed"
 }
 
 
-@test "Output of \"docxbox mm nonexistent.docx\" is an error message" {
+@test "Case 12: Output of \"docxbox mm nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} mm nonexistent.docx
   [ "$status" -ne 0 ]
   check_for_valgrind_error
@@ -152,7 +152,7 @@ revision="the meta attribute \"revision\" can be changed"
 }
 
 argument="{meta_attribute} {argument}"
-@test "Output of \"docxbox mm ${argument} wrong_file_type\" is an error message" {
+@test "Case 12: Output of \"docxbox mm ${argument} wrong_file_type\" is an error message" {
   pattern="docxBox Error - File is no ZIP archive:"
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"

--- a/test/functional/rmt.bats.sh
+++ b/test/functional/rmt.bats.sh
@@ -28,7 +28,7 @@ PATH_DOCX_NEW="test/tmp/cp_plain_text.docx"
 PATH_DOCX_STYLES="test/tmp/cp_text_with_styles.docx"
 ERR_LOG="test/tmp/err.log"
 
-@test "Output of \"docxbox rmt {missing filename}\" is an error message" {
+@test "Case 1: Output of \"docxbox rmt {missing filename}\" is an error message" {
   run ${DOCXBOX_BINARY} rmt
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: DOCX filename" = "${lines[0]}" ]
@@ -36,7 +36,7 @@ ERR_LOG="test/tmp/err.log"
   check_for_valgrind_error
 }
 
-title="Output of \"docxbox rmt filename.docx {missing arguments}\" "
+title="Case 2: Output of \"docxbox rmt filename.docx {missing arguments}\" "
 title+="is an error message"
 @test "${title}" {
   pattern="docxBox Error - Missing argument: \
@@ -49,8 +49,8 @@ String left-hand-side of part to be removed"
   check_for_valgrind_error
 }
 
-title_missing_argument="Output of \"docxbox rmt filename.docx leftHandString \
-{missing_argument}\" is an error message"
+title_missing_argument="Case 3: Output of \"docxbox rmt filename.docx \
+leftHandString {missing_argument}\" is an error message"
 @test "${title_missing_argument}" {
   pattern="docxBox Error - Missing argument: \
 String right-hand-side of part to be removed"
@@ -62,8 +62,8 @@ String right-hand-side of part to be removed"
   check_for_valgrind_error
 }
 
-title_base_functionality="With \"docxbox rmt filename.docx leftHandString \
-rightHandString\" removes text between and including given strings"
+title_base_functionality="Case 4: With \"docxbox rmt filename.docx \
+leftHandString rightHandString\" removes text between and including given strings"
 @test "${title_base_functionality}" {
   pattern="Fugiat excepteursed in qui sit velit duis veniam."
 
@@ -77,7 +77,7 @@ rightHandString\" removes text between and including given strings"
   ${DOCXBOX_BINARY} txt "${PATH_DOCX}" | grep --count --invert-match "${pattern}"
 }
 
-@test "Removing strings at the beginning of a file" {
+@test "Case 5: Removing strings at the beginning of a file" {
   ${DOCXBOX_BINARY} rmt "${PATH_DOCX_NEW}" "THIS" "TITLE"
 
   check_for_valgrind_error
@@ -85,7 +85,7 @@ rightHandString\" removes text between and including given strings"
   ${DOCXBOX_BINARY} txt "${PATH_DOCX_NEW}" | grep --count "IN ALL CAPS"
 }
 
-@test "Removing strings at the beginning of a file within a sentence" {
+@test "Case 6: Removing strings at the beginning of a file within a sentence" {
   ${DOCXBOX_BINARY} rmt "${PATH_DOCX_NEW}" "TITLE" "ALL"
 
   check_for_valgrind_error
@@ -93,7 +93,7 @@ rightHandString\" removes text between and including given strings"
   ${DOCXBOX_BINARY} txt "${PATH_DOCX_NEW}" | grep --count "THIS IS A  CAPS"
 }
 
-@test "Removing strings in the middle of a file" {
+@test "Case 7: Removing strings in the middle of a file" {
   pattern="Text in cursive"
 
   ${DOCXBOX_BINARY} rmt "${PATH_DOCX_NEW}" "style" "cursive"
@@ -103,7 +103,7 @@ rightHandString\" removes text between and including given strings"
   ${DOCXBOX_BINARY} txt "${PATH_DOCX_NEW}" | grep --count --invert-match "${pattern}"
 }
 
-@test "Removing strings in the middle of a file within a sentence" {
+@test "Case 8: Removing strings in the middle of a file within a sentence" {
   pattern="A style"
 
   ${DOCXBOX_BINARY} rmt "${PATH_DOCX_NEW}" " paragraph" "special"
@@ -113,7 +113,7 @@ rightHandString\" removes text between and including given strings"
   ${DOCXBOX_BINARY} txt "${PATH_DOCX_NEW}" | grep --count "${pattern}"
 }
 
-@test "Removing strings with different styles" {
+@test "Case 9: Removing strings with different styles" {
   ${DOCXBOX_BINARY} rmt "${PATH_DOCX_NEW}" "CAPS" "paragraph"
 
   check_for_valgrind_error
@@ -121,7 +121,7 @@ rightHandString\" removes text between and including given strings"
   ${DOCXBOX_BINARY} txt "${PATH_DOCX_NEW}" | grep --count "without special style"
 }
 
-@test "Removing strings at the end of a file" {
+@test "Case 10: Removing strings at the end of a file" {
   pattern="Bold text passages are great"
 
   before_rmt=$(${DOCXBOX_BINARY} txt "${PATH_DOCX_NEW}" | wc --words)
@@ -135,7 +135,7 @@ rightHandString\" removes text between and including given strings"
   (( before_rmt = after_rmt ))
 }
 
-@test "Trying to remove strings at the end of a file with a nonexistent string" {
+@test "Case 11: Trying to remove strings at the end of a file with a nonexistent string" {
   pattern="Bold text passages are great"
 
   ${DOCXBOX_BINARY} rmt "${PATH_DOCX_NEW}" "Bold" "Foo"
@@ -145,7 +145,7 @@ rightHandString\" removes text between and including given strings"
   ${DOCXBOX_BINARY} txt "${PATH_DOCX_NEW}" | grep --count "${pattern}"
 }
 
-@test "Removing content between two given strings removes everything" {
+@test "Case 12: Removing content between two given strings removes everything" {
   ${DOCXBOX_BINARY} lsi "${PATH_DOCX_STYLES}" | grep --count "image1.png"
 
   run ${DOCXBOX_BINARY} rmt "${PATH_DOCX_STYLES}" "FROM" "Until"
@@ -160,7 +160,7 @@ rightHandString\" removes text between and including given strings"
   ${DOCXBOX_BINARY} lsi "${PATH_DOCX_STYLES}" | grep --invert-match "image1.png"
 }
 
-@test "Output of \"docxbox rmt nonexistent.docx\" is an error message" {
+@test "Case 13: Output of \"docxbox rmt nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} rmt nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -169,7 +169,7 @@ rightHandString\" removes text between and including given strings"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox rmt wrong_file_type\" is an error message" {
+@test "Case 14: Output of \"docxbox rmt wrong_file_type\" is an error message" {
   pattern="docxBox Error - File is no ZIP archive:"
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"

--- a/test/functional/rpi.bats.sh
+++ b/test/functional/rpi.bats.sh
@@ -27,7 +27,7 @@ PATH_JPEG="test/assets/images/2100x400.jpeg"
 
 BASE_COMMAND="docxbox rpi filename.docx"
 
-@test "Output of \"docxbox rpi {missing filename}\" is an error message" {
+@test "Case 1: Output of \"docxbox rpi {missing filename}\" is an error message" {
   run ${DOCXBOX_BINARY} rpi
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: DOCX filename" = "${lines[0]}" ]
@@ -35,7 +35,7 @@ BASE_COMMAND="docxbox rpi filename.docx"
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND} {missing argument}\" is an error message" {
+@test "Case 2: Output of \"${BASE_COMMAND} {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} rpi "${PATH_DOCX}"
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: Filename of image to be replaced" = "${lines[0]}" ]
@@ -44,7 +44,7 @@ BASE_COMMAND="docxbox rpi filename.docx"
 }
 
 missing_argument="imageName {missingReplacementImageName}"
-@test "Output of \"${BASE_COMMAND} ${missing_argument}\" is an error message" {
+@test "Case 3: Output of \"${BASE_COMMAND} ${missing_argument}\" is an error message" {
   run ${DOCXBOX_BINARY} rpi "${PATH_DOCX}" image2.jpeg
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: Filename of replacement image" = "${lines[0]}" ]
@@ -53,7 +53,7 @@ missing_argument="imageName {missingReplacementImageName}"
 }
 
 appendix="an image can be replaced"
-@test "With \"${BASE_COMMAND} imageName replacementImageName\" ${appendix}" {
+@test "Case 4: With \"${BASE_COMMAND} imageName replacementImageName\" ${appendix}" {
 
   run ${DOCXBOX_BINARY} rpi "${PATH_DOCX}" image2.jpeg "${PATH_JPEG}"
   [ "$status" -eq 0 ]
@@ -69,7 +69,7 @@ appendix="an image can be replaced"
 
 arguments="imageName replacementImageName newFilename.docx"
 appendix_new_docx="an image can be replaced and saved to new doxc"
-@test "With \"${BASE_COMMAND} ${arguments}\" ${appendix_new_docx}" {
+@test "Case 5: With \"${BASE_COMMAND} ${arguments}\" ${appendix_new_docx}" {
   path_docx_out="test/tmp/newImage.docx"
 
   run ${DOCXBOX_BINARY} rpi "${PATH_DOCX}" image2.jpeg "${PATH_JPEG}" "${path_docx_out}"
@@ -84,7 +84,7 @@ appendix_new_docx="an image can be replaced and saved to new doxc"
   file "${PATH_EXTRACTED_IMAGE}" | grep --count "2100x400"
 }
 
-@test "Output of \"${BASE_COMMAND} nonexistent.image\" is an error message" {
+@test "Case 6: Output of \"${BASE_COMMAND} nonexistent.image\" is an error message" {
   error_message="docxBox Error - Copy file failed - file not found:"
 
   ${DOCXBOX_BINARY} rpi "${PATH_DOCX}" image2.jpeg nonexistent.jpeg 2>&1 | tee "${ERR_LOG}"
@@ -92,7 +92,7 @@ appendix_new_docx="an image can be replaced and saved to new doxc"
   cat "${ERR_LOG}" | grep --count "${error_message}"
 }
 
-@test "Output of \"docxbox rpi nonexistent.docx\" is an error message" {
+@test "Case 7: Output of \"docxbox rpi nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} rpi nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -101,7 +101,7 @@ appendix_new_docx="an image can be replaced and saved to new doxc"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox rpi wrong_file_type\" is an error message" {
+@test "Case 8: Output of \"docxbox rpi wrong_file_type\" is an error message" {
   pattern="docxBox Error - File is no ZIP archive:"
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"

--- a/test/functional/rpt.bats.sh
+++ b/test/functional/rpt.bats.sh
@@ -27,7 +27,7 @@ DISPLAY_FILE="word/document.xml"
 
 BASE_COMMAND="docxbox rpt filename.docx"
 
-@test "Output of \"docxbox rpt {missing filename}\" ${ERROR}" {
+@test "Case 1: Output of \"docxbox rpt {missing filename}\" ${ERROR}" {
   run ${DOCXBOX_BINARY} rpt
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: DOCX filename" = "${lines[0]}" ]
@@ -35,7 +35,7 @@ BASE_COMMAND="docxbox rpt filename.docx"
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND} {missing arguments}\" ${ERROR}" {
+@test "Case 2: Output of \"${BASE_COMMAND} {missing arguments}\" ${ERROR}" {
   pattern="docxBox Error - Missing argument: String to be found (and replaced)"
 
   run ${DOCXBOX_BINARY} rpt "${PATH_DOCX}"
@@ -46,7 +46,7 @@ BASE_COMMAND="docxbox rpt filename.docx"
 }
 
 missing_argument="stringToBeReplaced {missing argument}"
-@test "Output of \"${BASE_COMMAND} ${missing_argument}\" ${ERROR}" {
+@test "Case 3: Output of \"${BASE_COMMAND} ${missing_argument}\" ${ERROR}" {
   run ${DOCXBOX_BINARY} rpt "${PATH_DOCX}" toBeReplaced
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: Replacement" = "${lines[0]}" ]
@@ -56,7 +56,7 @@ missing_argument="stringToBeReplaced {missing argument}"
 
 ARGUMENTS="stringToBeReplaced replacementString"
 appendix="the stringToBeReplaced gets replaced"
-@test "With \"${BASE_COMMAND} ${ARGUMENTS}\" ${appendix}" {
+@test "Case 4: With \"${BASE_COMMAND} ${ARGUMENTS}\" ${appendix}" {
   run ${DOCXBOX_BINARY} rpt "${PATH_DOCX}" Lorem Dorem
   [ "$status" -eq 0 ]
 
@@ -67,7 +67,7 @@ appendix="the stringToBeReplaced gets replaced"
 
 arguments_new_docx="stringToBeReplaced replacementString newFile.docx"
 appendix_new_docx="the stringToBeReplaced gets replaced and is saved to new file"
-@test "With \"${BASE_COMMAND} ${arguments_new_docx}\" ${appendix_new_docx}" {
+@test "Case 5: With \"${BASE_COMMAND} ${arguments_new_docx}\" ${appendix_new_docx}" {
   path_docx_out="test/tmp/replacedString.docx"
 
   run ${DOCXBOX_BINARY} rpt "${PATH_DOCX}" Lorem Dorem "${path_docx_out}"
@@ -78,7 +78,7 @@ appendix_new_docx="the stringToBeReplaced gets replaced and is saved to new file
   ${DOCXBOX_BINARY} txt "${path_docx_out}" | grep --count Dorem
 }
 
-title_h1="With \"${BASE_COMMAND} heading_as_JSON\" the given string is \
+title_h1="Case 6: With \"${BASE_COMMAND} heading_as_JSON\" the given string is \
 replaced by a h1"
 @test "${title_h1}" {
   heading="{\"h1\":{\"text\":\"Foo\"}}"
@@ -94,7 +94,7 @@ replaced by a h1"
   ${DOCXBOX_BINARY} lsl "${PATH_DOCX}" "para1" | grep --count "${DISPLAY_FILE}"
 }
 
-title_h2="With \"${BASE_COMMAND} heading_as_JSON\" the given string is \
+title_h2="Case 7: With \"${BASE_COMMAND} heading_as_JSON\" the given string is \
 replaced by a h2"
 @test "${title_h2}" {
   heading="{\"h2\":{\"text\":\"Foo\"}}"
@@ -110,7 +110,7 @@ replaced by a h2"
   ${DOCXBOX_BINARY} lsl "${PATH_DOCX}" "para2" | grep --count "${DISPLAY_FILE}"
 }
 
-title_h3="With \"${BASE_COMMAND} heading_as_JSON\" the given string is \
+title_h3="Case 8: With \"${BASE_COMMAND} heading_as_JSON\" the given string is \
 replaced by a h3"
 @test "${title_h3}" {
   heading="{\"h3\":{\"text\":\"Foo\"}}"
@@ -126,8 +126,8 @@ replaced by a h3"
   ${DOCXBOX_BINARY} lsl "${PATH_DOCX}" "para3" | grep --count "${DISPLAY_FILE}"
 }
 
-title_ul="With \"${BASE_COMMAND} ul_as_JSON\" the given string is replaced by \
-a unordered list"
+title_ul="Case 9: With \"${BASE_COMMAND} ul_as_JSON\" the given string is \
+replaced by a unordered list"
 @test "${title_ul}" {
   list="{\"ul\":{\"items\":[\"item-1\",\"item-2\",\"item-3\"]}}"
 
@@ -142,8 +142,8 @@ a unordered list"
   ${DOCXBOX_BINARY} lsl "${PATH_DOCX_NEW}" "w:numPr" | grep --count "${DISPLAY_FILE}"
 }
 
-title_hyperlink="With \"${BASE_COMMAND} hyperlink_as_JSON\" the given string \
-is replaced by a hyperlink"
+title_hyperlink="Case 10: With \"${BASE_COMMAND} hyperlink_as_JSON\" the given \
+string is replaced by a hyperlink"
 @test "${title_hyperlink}" {
   url="\"url\":\"https://github.com/gyselroth/docxbox\""
   link="{\"link\":{\"text\":\"docxBox\",${url}}}"
@@ -160,7 +160,7 @@ is replaced by a hyperlink"
 }
 
 image_replacement="the given string is replaced by an image"
-@test "With \"${BASE_COMMAND} image_as_JSON\" ${image_replacement} using EMU" {
+@test "Case 11: With \"${BASE_COMMAND} image_as_JSON\" ${image_replacement} using EMU" {
   image="{\"image\":{\"size\":[2438400,1828800]}}"
   image_path="test/assets/images/2100x400.jpeg"
 
@@ -178,7 +178,7 @@ image_replacement="the given string is replaced by an image"
   ${DOCXBOX_BINARY} lsl "${PATH_DOCX}" "</w:drawing>" | grep --count "${DISPLAY_FILE}"
 }
 
-@test "With \"${BASE_COMMAND} image_as_JSON\" ${image_replacement} using pixels" {
+@test "Case 12: With \"${BASE_COMMAND} image_as_JSON\" ${image_replacement} using pixels" {
   image="{\"image\":{\"size\":[\"2100px\",\"400px\"]}}"
   image_path="test/assets/images/2100x400.jpeg"
 
@@ -196,8 +196,8 @@ image_replacement="the given string is replaced by an image"
   ${DOCXBOX_BINARY} lsl "${PATH_DOCX}" "</w:drawing>" | grep --count "${DISPLAY_FILE}"
 }
 
-title_table="With \"${BASE_COMMAND} table_as_JSON\" the given string is \
-replaced by a table"
+title_table="Case 13: With \"${BASE_COMMAND} table_as_JSON\" the given string \
+is replaced by a table"
 @test "${title_table}" {
   header="\"header\":[\"header_one\",\"B\",\"C\"]"
   first_column="[\"a1\",\"a2\",\"a3\"]"
@@ -219,8 +219,8 @@ replaced by a table"
   ${DOCXBOX_BINARY} lsl "${PATH_DOCX}" "<w:tbl>" | grep --count "${DISPLAY_FILE}"
 }
 
-title_table_as_JSON="With \"${BASE_COMMAND} table_as_JSON\" the given string \
-is replaced by a table with header"
+title_table_as_JSON="Case 14: With \"${BASE_COMMAND} table_as_JSON\" the given \
+string is replaced by a table with header"
 @test "${title_table_as_JSON}" {
   header="\"header\":[\"header_one\",\"B\",\"C\"]"
   first_column="[\"a1\",\"a2\",\"a3\"]"
@@ -242,8 +242,8 @@ is replaced by a table with header"
   ${DOCXBOX_BINARY} cat "${PATH_DOCX}" "${DISPLAY_FILE}" | grep --count -q "header_one"
 }
 
-title_case_sensitive="With \"${BASE_COMMAND} lower_case_string\" the given \
-string gets replaced case sensitive"
+title_case_sensitive="Case 15: With \"${BASE_COMMAND} lower_case_string\" the \
+given string gets replaced case sensitive"
 @test "${title_case_sensitive}" {
   run ${DOCXBOX_BINARY} rpt "${PATH_DOCX_NEW}" "text" "FooBar"
   [ "$status" -eq 0 ]
@@ -255,7 +255,7 @@ string gets replaced case sensitive"
   ${DOCXBOX_BINARY} txt "${PATH_DOCX_NEW}" | grep --count --invert-match "text"
 }
 
-@test "Output of \"docxbox rpt ${ARGUMENTS} nonexistent.docx\" ${ERROR}" {
+@test "Case 16: Output of \"docxbox rpt ${ARGUMENTS} nonexistent.docx\" ${ERROR}" {
   run ${DOCXBOX_BINARY} rpt nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -268,7 +268,7 @@ string gets replaced case sensitive"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox rpt ${ARGUMENTS} wrong_file_type\" ${ERROR}" {
+@test "Case 17: Output of \"docxbox rpt ${ARGUMENTS} wrong_file_type\" ${ERROR}" {
   pattern="docxBox Error - File is no ZIP archive:"
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"

--- a/test/functional/sfv.bats.sh
+++ b/test/functional/sfv.bats.sh
@@ -29,7 +29,7 @@ MERGEFIELD_FOOTER="MERGEFIELD  Mergefield_Footer"
 
 ARGUMENTS="filename.docx fieldIdentifier fieldValue"
 
-@test "Output of \"${BASE_COMMAND} {missing argument}\" is an error message" {
+@test "Case 1: Output of \"${BASE_COMMAND} {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Filename of DOCX to be extracted"
 
   run ${DOCXBOX_BINARY} sfv
@@ -40,7 +40,7 @@ ARGUMENTS="filename.docx fieldIdentifier fieldValue"
 }
 
 missing_arguments="filename.docx {missing argument}"
-@test "Output of \"${BASE_COMMAND} ${missing_arguments}\" is an error message" {
+@test "Case 2: Output of \"${BASE_COMMAND} ${missing_arguments}\" is an error message" {
   run ${DOCXBOX_BINARY} sfv "${PATH_DOCX}"
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: Field identifier" = "${lines[0]}" ]
@@ -49,7 +49,7 @@ missing_arguments="filename.docx {missing argument}"
 }
 
 missing_value="filename.docx fieldIdentifier {missing argument}"
-@test "Output of \"${BASE_COMMAND} ${missing_value}\" is an error message" {
+@test "Case 3: Output of \"${BASE_COMMAND} ${missing_value}\" is an error message" {
   run ${DOCXBOX_BINARY} sfv "${PATH_DOCX}" "${MERGEFIELD}"
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: Value to be set" = "${lines[0]}" ]
@@ -58,7 +58,7 @@ missing_value="filename.docx fieldIdentifier {missing argument}"
 }
 
 appendix=" the value of the given field is changed"
-@test "With \"${BASE_COMMAND} ${ARGUMENTS}\" ${appendix}" {
+@test "Case 4: With \"${BASE_COMMAND} ${ARGUMENTS}\" ${appendix}" {
   run ${DOCXBOX_BINARY} sfv "${PATH_DOCX}" "${MERGEFIELD}" foobar
   [ "$status" -eq 0 ]
 
@@ -67,7 +67,9 @@ appendix=" the value of the given field is changed"
   ${DOCXBOX_BINARY} txt "${PATH_DOCX}" | grep --count "foobar"
 }
 
-@test "With \"${BASE_COMMAND} ${ARGUMENTS}\" the value of the MERGEFIELD in the header gets changed" {
+title_header="Case 5: With \"${BASE_COMMAND} ${ARGUMENTS}\" the value of the \
+MERGEFIELD in the header gets changed"
+@test "${title_header}" {
   run ${DOCXBOX_BINARY} sfv "${PATH_DOCX}" "${MERGEFIELD_HEADER}" foobar
   [ "$status" -eq 0 ]
 
@@ -76,7 +78,9 @@ appendix=" the value of the given field is changed"
   ${DOCXBOX_BINARY} txt "${PATH_DOCX}" | grep --count "foobar"
 }
 
-@test "With \"${BASE_COMMAND} ${ARGUMENTS}\" the value of the MERGEFIELD in the footer gets changed" {
+title_footer="Case 6: With \"${BASE_COMMAND} ${ARGUMENTS}\" the value of the \
+MERGEFIELD in the footer gets changed"
+@test "${title_footer}" {
   run ${DOCXBOX_BINARY} sfv "${PATH_DOCX}" "${MERGEFIELD_FOOTER}" foobar
   [ "$status" -eq 0 ]
 
@@ -85,7 +89,7 @@ appendix=" the value of the given field is changed"
   ${DOCXBOX_BINARY} txt "${PATH_DOCX}" | grep --count "foobar"
 }
 
-@test "Output of \"docxbox sfv nonexistent.docx\" is an error message" {
+@test "Case 7: Output of \"docxbox sfv nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} sfv nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -95,7 +99,7 @@ appendix=" the value of the given field is changed"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-title="Output of \"docxbox fieldIdentifier fieldValue wrong_file_type\" "
+title="Case 8: Output of \"docxbox fieldIdentifier fieldValue wrong_file_type\" "
 title+="is an error message"
 @test "${title}" {
   pattern="docxBox Error - File is no ZIP archive:"

--- a/test/functional/txt.bats.sh
+++ b/test/functional/txt.bats.sh
@@ -24,7 +24,7 @@ ERR_LOG="test/tmp/err.log"
 BASE_COMMAND="docxbox txt filename.docx"
 APPENDIX="is the segmented plain text from given file"
 
-@test "Output of \"docxbox txt {missing argument}\" is an error message" {
+@test "Case 1: Output of \"docxbox txt {missing argument}\" is an error message" {
   run ${DOCXBOX_BINARY} txt
   [ "$status" -ne 0 ]
   [ "docxBox Error - Missing argument: Filename of DOCX to be extracted" = "${lines[0]}" ]
@@ -32,13 +32,13 @@ APPENDIX="is the segmented plain text from given file"
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND}\" is the the plain text from given file" {
+@test "Case 2: Output of \"${BASE_COMMAND}\" is the the plain text from given file" {
   ${DOCXBOX_BINARY} txt "${PATH_DOCX}" | grep --count "Officia"
 
   check_for_valgrind_error
 }
 
-@test "Output of \"${BASE_COMMAND} -s \" ${APPENDIX}" {
+@test "Case 3: Output of \"${BASE_COMMAND} -s \" ${APPENDIX}" {
   segmented=$(${DOCXBOX_BINARY} txt "${PATH_DOCX}" -s | wc --lines)
   non_segmented=$(${DOCXBOX_BINARY} txt "${PATH_DOCX}" | wc --lines)
 
@@ -48,7 +48,7 @@ APPENDIX="is the segmented plain text from given file"
 
 }
 
-@test "Output of \"${BASE_COMMAND} --segments \" ${APPENDIX}" {
+@test "Case 4: Output of \"${BASE_COMMAND} --segments \" ${APPENDIX}" {
   segmented=$(${DOCXBOX_BINARY} txt "${PATH_DOCX}" --segments | wc --lines)
   non_segmented=$(${DOCXBOX_BINARY} txt "${PATH_DOCX}" | wc --lines)
 
@@ -57,7 +57,7 @@ APPENDIX="is the segmented plain text from given file"
   (( ${segmented} > ${non_segmented} ))
 }
 
-@test "Output of \"docxbox txt nonexistent.docx\" is an error message" {
+@test "Case 5: Output of \"docxbox txt nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} txt nonexistent.docx
   [ "$status" -ne 0 ]
 
@@ -67,7 +67,7 @@ APPENDIX="is the segmented plain text from given file"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox txt wrong_file_type\" is an error message" {
+@test "Case 6: Output of \"docxbox txt wrong_file_type\" is an error message" {
   pattern="docxBox Error - File is no ZIP archive:"
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"

--- a/test/functional/uz.bats.sh
+++ b/test/functional/uz.bats.sh
@@ -22,7 +22,7 @@ ERR_LOG="test/tmp/err.log"
 
 UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
 
-@test "Output of \"docxbox uz {missing argument}\" is an error message" {
+@test "Case 1: Output of \"docxbox uz {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Filename of DOCX to be extracted"
 
   run ${DOCXBOX_BINARY} uz
@@ -32,7 +32,7 @@ UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox uz nonexistent.docx\" is an error message" {
+@test "Case 2: Output of \"docxbox uz nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} uz nonexistent.docx
   [ "$status" -ne 0 ]
   check_for_valgrind_error
@@ -41,7 +41,7 @@ UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox uz wrong_file_type\" is an error message" {
+@test "Case 3: Output of \"docxbox uz wrong_file_type\" is an error message" {
   pattern="docxBox Error - File is no ZIP archive:"
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
@@ -56,7 +56,7 @@ UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
   done
 }
 
-@test "With \"docxbox uz filename.docx\" all files are unziped" {
+@test "Case 4: With \"docxbox uz filename.docx\" all files are unziped" {
   pattern="^[[:space:]]\{4\}"
 
   run ${DOCXBOX_BINARY} uz test/tmp/cp_bio_assay.docx
@@ -66,7 +66,7 @@ UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
   cat "${UNZIPPED_FOLDER}/word/document.xml" | grep --invert-match "${pattern}"
 }
 
-@test "Unziped files are located in project root" {
+@test "Case 5: Unziped files are located in project root" {
   ls | grep --count "${UNZIPPED_FOLDER}"
 
   if [ -d "${UNZIPPED_FOLDER}" ]; then

--- a/test/functional/uzi.bats.sh
+++ b/test/functional/uzi.bats.sh
@@ -23,7 +23,7 @@ ERR_LOG="test/tmp/err.log"
 
 UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
 
-@test "Output of \"docxbox uzi {missing argument}\" is an error message" {
+@test "Case 1: Output of \"docxbox uzi {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Filename of DOCX to be extracted"
 
   run ${DOCXBOX_BINARY} uzi
@@ -33,7 +33,7 @@ UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox uzi nonexistent.docx\" is an error message" {
+@test "Case 2: Output of \"docxbox uzi nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} uzi nonexistent.docx
   [ "$status" -ne 0 ]
   check_for_valgrind_error
@@ -42,7 +42,7 @@ UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox uzi wrong_file_type\" is an error message" {
+@test "Case 3: Output of \"docxbox uzi wrong_file_type\" is an error message" {
   pattern="docxBox Error - File is no ZIP archive:"
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
@@ -57,7 +57,7 @@ UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
   done
 }
 
-@test "With of \"docxbox uzi filename.docx\" all files are unzipped" {
+@test "Case 4: With of \"docxbox uzi filename.docx\" all files are unzipped" {
   run ${DOCXBOX_BINARY} uzi "${PATH_DOCX}"
   [ "$status" -eq 0 ]
   check_for_valgrind_error
@@ -65,7 +65,7 @@ UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
   cat "${UNZIPPED_FOLDER}/word/document.xml" | grep "^[[:space:]]\{4\}"
 }
 
-@test "Unzipped files are located in project root" {
+@test "Case 5: Unzipped files are located in project root" {
   ls | grep --count "${UNZIPPED_FOLDER}"
 
   if [ -d "${UNZIPPED_FOLDER}" ]; then
@@ -73,7 +73,7 @@ UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
   fi
 }
 
-@test "With of \"docxbox uz filename.docx -i\" all files are unzipped" {
+@test "Case 6: With of \"docxbox uz filename.docx -i\" all files are unzipped" {
   run ${DOCXBOX_BINARY} uz "${PATH_DOCX}" -i
   [ "$status" -eq 0 ]
 
@@ -82,7 +82,7 @@ UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
   cat "${UNZIPPED_FOLDER}/word/document.xml" | grep "^[[:space:]]\{4\}"
 }
 
-@test "Unzipped files are located in project root after running uz -i" {
+@test "Case 7: Unzipped files are located in project root after running uz -i" {
   ls | grep --count "${UNZIPPED_FOLDER}"
 
   if [ -d "${UNZIPPED_FOLDER}" ]; then
@@ -90,7 +90,7 @@ UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
   fi
 }
 
-@test "With of \"docxbox uz filename.docx --indent\" all files are unzipped" {
+@test "Case 8: With of \"docxbox uz filename.docx --indent\" all files are unzipped" {
   run ${DOCXBOX_BINARY} uz "${PATH_DOCX}" --indent
   [ "$status" -eq 0 ]
 
@@ -99,7 +99,7 @@ UNZIPPED_FOLDER="cp_bio_assay.docx-extracted"
   cat "${UNZIPPED_FOLDER}/word/document.xml" | grep "^[[:space:]]\{4\}"
 }
 
-@test "Unzipped files are located in project root after running uz --indent" {
+@test "Case 9: Unzipped files are located in project root after running uz --indent" {
   ls | grep --count "${UNZIPPED_FOLDER}"
 
   if [ -d "${UNZIPPED_FOLDER}" ]; then

--- a/test/functional/uzm.bats.sh
+++ b/test/functional/uzm.bats.sh
@@ -24,7 +24,7 @@ ERR_LOG="test/tmp/err.log"
 DESCRIPTION="only media files are extracted"
 UNZIPPED_DOCX="cp_table_unordered_list_images.docx-media-extracted"
 
-@test "Output of \"docxbox uzm {missing argument}\" is an error message" {
+@test "Case 1: Output of \"docxbox uzm {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Filename of DOCX to be extracted"
 
   run ${DOCXBOX_BINARY} uzm
@@ -34,7 +34,7 @@ UNZIPPED_DOCX="cp_table_unordered_list_images.docx-media-extracted"
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox uzm nonexistent.docx\" is an error message" {
+@test "Case 2: Output of \"docxbox uzm nonexistent.docx\" is an error message" {
   run ${DOCXBOX_BINARY} uzm nonexistent.docx
   [ "$status" -ne 0 ]
   check_for_valgrind_error
@@ -43,7 +43,7 @@ UNZIPPED_DOCX="cp_table_unordered_list_images.docx-media-extracted"
   cat "${ERR_LOG}" | grep --count "docxBox Error - File not found:"
 }
 
-@test "Output of \"docxbox uzm wrong_file_type\" is an error message" {
+@test "Case 3: Output of \"docxbox uzm wrong_file_type\" is an error message" {
   pattern="docxBox Error - File is no ZIP archive:"
   wrong_file_types=(
   "test/tmp/cp_lorem_ipsum.pdf"
@@ -58,13 +58,13 @@ UNZIPPED_DOCX="cp_table_unordered_list_images.docx-media-extracted"
   done
 }
 
-@test "With \"docxbox uzm filename.docx\" ${DESCRIPTION}" {
+@test "Case 4: With \"docxbox uzm filename.docx\" ${DESCRIPTION}" {
   run ${DOCXBOX_BINARY} uzm "${PATH_DOCX}"
 
   check_for_valgrind_error
 }
 
-@test "Unzipped files are located in project root" {
+@test "Case 5: Unzipped files are located in project root" {
   ls | grep --count "${UNZIPPED_DOCX}"
 
   if [ -d "${UNZIPPED_DOCX}" ]; then
@@ -72,13 +72,13 @@ UNZIPPED_DOCX="cp_table_unordered_list_images.docx-media-extracted"
   fi
 }
 
-@test "With \"docxbox uz filename.docx --media\" ${DESCRIPTION}" {
+@test "Case 6: With \"docxbox uz filename.docx --media\" ${DESCRIPTION}" {
   run ${DOCXBOX_BINARY} uz "${PATH_DOCX}" --media
 
   check_for_valgrind_error
 }
 
-@test "Unzipped files are located in project root after running uz --media " {
+@test "Case 7: Unzipped files are located in project root after running uz --media " {
   ls | grep --count "${UNZIPPED_DOCX}"
 
   if [ -d "${UNZIPPED_DOCX}" ]; then
@@ -86,13 +86,13 @@ UNZIPPED_DOCX="cp_table_unordered_list_images.docx-media-extracted"
   fi
 }
 
-@test "With \"docxbox uz filename.docx -m\" ${DESCRIPTION}" {
+@test "Case 8: With \"docxbox uz filename.docx -m\" ${DESCRIPTION}" {
   run ${DOCXBOX_BINARY} uz "${PATH_DOCX}" -m
 
   check_for_valgrind_error
 }
 
-@test "Unzipped files are located in project root after running uz -m" {
+@test "Case 9: Unzipped files are located in project root after running uz -m" {
   ls | grep --count "${UNZIPPED_DOCX}"
 
   if [ -d "${UNZIPPED_DOCX}" ]; then

--- a/test/functional/version.bats.sh
+++ b/test/functional/version.bats.sh
@@ -18,7 +18,7 @@ else
   DOCXBOX_BINARY="$BATS_TEST_DIRNAME/../tmp/docxbox"
 fi
 
-@test "\"docxbox v\" displays version number" {
+@test "Case 1: \"docxbox v\" displays version number" {
   pattern="(^|\s)+(docxBox version )\K([0-9]|\.)*(?=\s|$)"
 
   ${DOCXBOX_BINARY} v | grep -Po "${pattern}"

--- a/test/functional/zp.bats.sh
+++ b/test/functional/zp.bats.sh
@@ -20,7 +20,7 @@ fi
 
 UNZIPPED_DOCX_DIRECTORY="test/tmp/unzipped"
 
-@test "Output of \"docxbox zp {missing argument}\" is an error message" {
+@test "Case 1: Output of \"docxbox zp {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Path of directory to be zipped"
 
   run ${DOCXBOX_BINARY} zp
@@ -30,7 +30,7 @@ UNZIPPED_DOCX_DIRECTORY="test/tmp/unzipped"
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox zp directory {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox zp directory {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Filename of docx to be created"
 
   run ${DOCXBOX_BINARY} zp "${UNZIPPED_DOCX_DIRECTORY}"
@@ -40,7 +40,7 @@ UNZIPPED_DOCX_DIRECTORY="test/tmp/unzipped"
   check_for_valgrind_error
 }
 
-title="With \"docxbox zp directory /path-to-file/filename.docx\" "
+title="Case 3: With \"docxbox zp directory /path-to-file/filename.docx\" "
 title+="a directory can be zipped into a docx"
 @test "$title" {
   if [ ! -d "${UNZIPPED_DOCX_DIRECTORY}" ]; then

--- a/test/functional/zpc.bats.sh
+++ b/test/functional/zpc.bats.sh
@@ -21,7 +21,7 @@ fi
 PATH_DOCX="test/tmp/cp_table_unordered_list_images.docx"
 UNZIPPED_DOCX_DIRECTORY="cp_table_unordered_list_images.docx-extracted"
 
-@test "Output of \"docxbox zpc {missing argument}\" is an error message" {
+@test "Case 1: Output of \"docxbox zpc {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Path of directory to be zipped"
 
   run ${DOCXBOX_BINARY} zpc
@@ -31,7 +31,7 @@ UNZIPPED_DOCX_DIRECTORY="cp_table_unordered_list_images.docx-extracted"
   check_for_valgrind_error
 }
 
-@test "Output of \"docxbox zpc directory {missing argument}\" is an error message" {
+@test "Case 2: Output of \"docxbox zpc directory {missing argument}\" is an error message" {
   pattern="docxBox Error - Missing argument: Filename of docx to be created"
 
   run ${DOCXBOX_BINARY} zpc "${UNZIPPED_DOCX_DIRECTORY}"
@@ -41,7 +41,7 @@ UNZIPPED_DOCX_DIRECTORY="cp_table_unordered_list_images.docx-extracted"
   check_for_valgrind_error
 }
 
-title="With \"docxbox zp directory /path-to-file/filename.docx\" "
+title="Case 3: With \"docxbox zp directory /path-to-file/filename.docx\" "
 title+="a directory can be zipped into a docx"
 @test "$title" {
   if [ ! -d "${UNZIPPED_DOCX_DIRECTORY}" ]; then


### PR DESCRIPTION
* implemented new testSuite cat.bats.sh

* implemented new testCase asserting if an error message is displayed when a none-existing image is given

* removed faulty docx files

* added corrected (and valid) docx files

* corrected testSuite after changes in mock-files

* corrected testSuite after changes in mock-files +1

* reverted accidentally committed test.sh

* corrected testSuite after changes in mock-files +1

* corrected testSuite after changes in mock-files +1

* reverted accidentally committed test.sh

* added corrected (and valid) docx files +1

* reverted accidentally committed test.sh

* corrected testSuite after changes in mock-files +1

* corrected testSuite after changes in mock-files +1

* corrected testSuite after changes in mock-files +1

* extended rpt.bats.sh - replace string by headings, ul, ol, hyperlink, image or table

* extended diff.bats.sh - assertion if a side-by-side view is displayed is more strict
extended ls.bats.sh - asserts if a side-by-side view is displayed

* corrected mock-file

* removed faulty docx

* added docx with valid mergefields

* removed faulty docx

* added docx with valid mergefields in header and footer

* corrected testSuite after merge with master-branch

* extended lsd.bats.sh - checks for fields in header and footer

* extended zp.bats.sh
added zpc.bats.sh

* extended rpt.bats.sh - added testCase asserting if text can be replaced by an image as JSON using pixels instead of EMUs

* resolves #59: added error collection

* corrected testSuite after changes in displayed messages
corrected if condition in test.sh

* added new exit code to test.sh depending if an error occurred
added new testCase to rpt.bats.sh - test asserts if table-header-row is contained
corrected txt.bats.sh after changes in displayed messages

* corrected image pathts after changes in file structure

* single testSuites can be called from cli as additional command

* removed duplicated double quotes

* changed meta attribute to make mockfile more generic

* changed meta attribute to make mockfile more generic +1

* added new testSuite batch.bats.sh

* split test case to assert if table-header is rendered into own test case

* extended mm.bats.sh - added new assertion to check output of mm command

* resolves #49

* correct testSuites after changes in mock-file +1

* began implementing valgrind support

* resolves #70: added new test case to assert meta attribute "created" doesn't change when modifying meta attribute "modified"

* finished integrating valgrind - no corresponding test cases yet

* finished integrating valgrind - removed unneeded global variable

* formatting

* refactored testSuite so valgrind can be used

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* correct testSuites after changes in mock-file +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* correct testSuites after changes in mock-file +1

* refactored testSuite so valgrind can be used +1

* correct testSuites after changes in mock-file +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* refactored testSuite so valgrind can be used +1

* removed unneeded global variable

* generalized testCase - made assertions dynamic instead of comparing hardcoded values

* removed deprecated testCase

* corrected testCase after changes within logging process

* code convention: capitalized global variables

* formatting

* extended rmt.bats.sh
added new mock-file with plain text in different styles to better test "rmt" command

* added new test case to rpt.bats.sh - test replacing a string case sensitive
reformatted test suite

* corrected testCase and made it more dynamic

* extended rmt.bats.sh - new testCases and commented out a (momentary) unsupported testCase

* changed valgrind log path

* reformatted testCase title to fit within grid
added new mock file

* extended rmt.bats.sh - added new cases with different approaches to remove content between two given strings

* fixed testCases after changes in mock-files
generalized mock-file

* added exemplary valgrind assertions

* added exemplary valgrind assertions -  made assertion more dynamic

* added full valgrind integration with assertions

* fixed failing test case

* fixed issue with valgrind in lsi.bats.sh and lsij.bats.sh

* extended batch.bats.sh - added new stable test cases for mm rmt and rpt commands

* corrected batch.bats.sh - fixed error in rpt testCase

* numbered all testCases to identify them clearly

* numbered all testCases to identify them clearly +1